### PR TITLE
Ensure Java dependencies are available on all platforms

### DIFF
--- a/source/Server.Contracts/DeploymentTools/InPathDeploymentTool.cs
+++ b/source/Server.Contracts/DeploymentTools/InPathDeploymentTool.cs
@@ -18,7 +18,7 @@ namespace Sashimi.Server.Contracts.DeploymentTools
         public Maybe<string> ToolPathVariableToSet { get; }
         public string[] SupportedPlatforms { get; }
 
-        public Maybe<DeploymentToolPackage> GetCompatiblePackage(string platform)
-            => platform == null ? new DeploymentToolPackage(this, Id).AsSome() : Maybe<DeploymentToolPackage>.None;
+        public virtual Maybe<DeploymentToolPackage> GetCompatiblePackage(string platform)
+            => new DeploymentToolPackage(this, Id).AsSome();
     }
 }


### PR DESCRIPTION
Forward-merging a bug fix from 2020.1 where Java dependency tools were not sent to the target for Tomcat and WildFly steps on non-Windows targets.