### PR TITLE
Packages `Calamari` projects into `Sashimi` nuget

### DIFF
--- a/source/Calamari.Terraform/Calamari.Terraform.csproj
+++ b/source/Calamari.Terraform/Calamari.Terraform.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Calamari.Terraform</AssemblyName>
+    <RootNamespace>Calamari.Terraform</RootNamespace>
+    <TargetFrameworks>netcoreapp3.1;net452</TargetFrameworks>   
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/source/Calamari.Terraform/Program.cs
+++ b/source/Calamari.Terraform/Program.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Calamari.Terraform
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("This is Calamari.Terraform from Sashimi");
+        }
+
+    }
+}

--- a/source/Sashimi.Terraform/ActionHandler/TerraformActionHandler.cs
+++ b/source/Sashimi.Terraform/ActionHandler/TerraformActionHandler.cs
@@ -66,6 +66,8 @@ namespace Sashimi.Terraform.ActionHandler
     /// </summary>
     public abstract class TerraformActionHandler : IActionHandler
     {
+        public static readonly CalamariFlavour CalamariTerraform = new CalamariFlavour("Calamari.Terraform");
+
         readonly ICloudTemplateHandlerFactory cloudTemplateHandlerFactory;
         
         public TerraformActionHandler(ICloudTemplateHandlerFactory cloudTemplateHandlerFactory)
@@ -85,8 +87,7 @@ namespace Sashimi.Terraform.ActionHandler
 
         public IActionHandlerResult Execute(IActionHanderContext context)
         {
-            var builder = context.CalamariCommand(CalamariFlavour.CalamariTerraform, ToolCommand)
-                .WithArgument("extensions", "Calamari.Terraform");
+            var builder = context.CalamariCommand(CalamariTerraform, ToolCommand);
 
             if (context.DeploymentTargetType.SelectValueOr(targetType => targetType != DeploymentTargetType.Ssh, true))
             {

--- a/source/Sashimi.Terraform/Sashimi.Terraform.csproj
+++ b/source/Sashimi.Terraform/Sashimi.Terraform.csproj
@@ -10,6 +10,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="..\..\artifacts\Calamari.Terraform.zip" LinkBase="tools" Pack="true" PackagePath="tools/" />
     <EmbeddedResource Include="**\*.ps1" />
     <EmbeddedResource Include="**\*.sh" />
   </ItemGroup>

--- a/source/Sashimi.sln
+++ b/source/Sashimi.sln
@@ -10,6 +10,20 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sashimi.Terraform.Tests", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sashimi.Tests.Shared", "Sashimi.Tests.Shared\Sashimi.Tests.Shared.csproj", "{2FA9B655-E72A-416E-AD0B-9A581AF8C4DB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Calamari.Terraform", "Calamari.Terraform\Calamari.Terraform.csproj", "{8706C920-B28F-4982-8CB5-E58AA3581534}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{A5977E44-894E-4B70-AE3A-78B514B44274}"
+ProjectSection(SolutionItems) = preProject
+	..\.gitattributes = ..\.gitattributes
+	..\.gitignore = ..\.gitignore
+	..\build.cake = ..\build.cake
+	..\build.cmd = ..\build.cmd
+	..\build.ps1 = ..\build.ps1
+	..\CODEOWNERS = ..\CODEOWNERS
+	..\gitversion.yml = ..\gitversion.yml
+	..\readme.md = ..\readme.md
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,9 +46,14 @@ Global
 		{2FA9B655-E72A-416E-AD0B-9A581AF8C4DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2FA9B655-E72A-416E-AD0B-9A581AF8C4DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2FA9B655-E72A-416E-AD0B-9A581AF8C4DB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8706C920-B28F-4982-8CB5-E58AA3581534}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8706C920-B28F-4982-8CB5-E58AA3581534}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8706C920-B28F-4982-8CB5-E58AA3581534}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8706C920-B28F-4982-8CB5-E58AA3581534}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{44851CEC-89D0-4D76-8BBA-2206308974D1} = {06CB7580-EC1B-44C3-93BC-0F58E6582EA1}
 		{C25C8D0B-7203-4BC4-A86F-7558FF890089} = {06CB7580-EC1B-44C3-93BC-0F58E6582EA1}
+		{8706C920-B28F-4982-8CB5-E58AA3581534} = {06CB7580-EC1B-44C3-93BC-0F58E6582EA1}
 	EndGlobalSection
 EndGlobal

--- a/source/Server.Contracts/Calamari/CalamariFlavour.cs
+++ b/source/Server.Contracts/Calamari/CalamariFlavour.cs
@@ -5,7 +5,6 @@
         public static readonly CalamariFlavour Calamari = new CalamariFlavour("Calamari");
         public static CalamariFlavour CalamariAws = new CalamariFlavour("Calamari.Cloud");
         public static readonly CalamariFlavour CalamariAzure = new CalamariFlavour("Calamari.Cloud");
-        public static readonly CalamariFlavour CalamariTerraform = new CalamariFlavour("Calamari.Cloud");
 
         public CalamariFlavour(string id)
         {

--- a/source/Server.Contracts/Sashimi.Server.Contracts.csproj
+++ b/source/Server.Contracts/Sashimi.Server.Contracts.csproj
@@ -6,7 +6,6 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <OutputPath>bin\</OutputPath>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
This puts the `Calamari` projects outputs in this repo into their corresponding `Sashimi` nuget packages as azip. The server will then look for these zips and consolidate them at build time.

We can merge this before `Calamari.Terraform` is ready with a minor change I noted.