### PR TITLE
Added a RunbookRun.Id known variable

### DIFF
--- a/source/Server.Contracts/KnownVariables.cs
+++ b/source/Server.Contracts/KnownVariables.cs
@@ -29,6 +29,11 @@
             }
         }
 
+        public static class RunbookRun
+        {
+            public static readonly string Id = "Octopus.RunbookRun.Id";
+        }
+
         public static class Certificate
         {
             public static string Name(string variableName)


### PR DESCRIPTION
Fixing https://github.com/OctopusDeploy/Issues/issues/6323 requires accessing the Octopus.RunbookRun.Id variable. This PR adds this constant as a known variable.