### PR TITLE
Remove quotes around octopus variable dictionary index names in Terraform plan and apply output

### DIFF
--- a/source/Calamari.Terraform.Tests/TerraformFixture.cs
+++ b/source/Calamari.Terraform.Tests/TerraformFixture.cs
@@ -215,9 +215,9 @@ namespace Calamari.Terraform.Tests
                     _.Set("Should_Be_Substituted_in_txt", "Hello World from text");
                 }, "WithVariablesSubstitution")
                 .Should()
-                .Contain("Octopus.Action[\"Step Name\"].Output.TerraformValueOutputs[\"my_output\"]' with the value only of 'Hello World'")
+                .Contain("Octopus.Action[Step Name].Output.TerraformValueOutputs[my_output]' with the value only of 'Hello World'")
                 .And
-                .Contain("Octopus.Action[\"Step Name\"].Output.TerraformValueOutputs[\"my_output_from_txt_file\"]' with the value only of 'Hello World from text'");
+                .Contain("Octopus.Action[Step Name].Output.TerraformValueOutputs[my_output_from_txt_file]' with the value only of 'Hello World from text'");
         }
         
         [Test]
@@ -273,7 +273,7 @@ namespace Calamari.Terraform.Tests
         public void TerraformPlanOutput(Type commandType)
         {
             ExecuteAndReturnLogOutput(commandType, _ => { _.Set("Octopus.Action.StepName", "Step Name"); }, "Simple")
-                .Should().Contain("Octopus.Action[\"Step Name\"].Output.TerraformPlanOutput");
+                .Should().Contain("Octopus.Action[Step Name].Output.TerraformPlanOutput");
         }
 
         [Test]
@@ -313,11 +313,11 @@ namespace Calamari.Terraform.Tests
             {
                 outputs.MoveNext();
                 outputs.Current.Should()
-                    .Contain("Octopus.Action[\"\"].Output.TerraformPlanOutput");
+                    .Contain("Octopus.Action[].Output.TerraformPlanOutput");
 
                 outputs.MoveNext();
                 outputs.Current.Should()
-                    .Contain($"Saving variable 'Octopus.Action[\"\"].Output.TerraformValueOutputs[\"url\"]' with the value only of '{appName}.azurewebsites.net'");
+                    .Contain($"Saving variable 'Octopus.Action[].Output.TerraformValueOutputs[url]' with the value only of '{appName}.azurewebsites.net'");
 
                 using (var client = new HttpClient())
                 {
@@ -355,11 +355,11 @@ namespace Calamari.Terraform.Tests
             {
                 outputs.MoveNext();
                 outputs.Current.Should()
-                    .Contain("Octopus.Action[\"\"].Output.TerraformPlanOutput");
+                    .Contain("Octopus.Action[].Output.TerraformPlanOutput");
 
                 outputs.MoveNext();
                 outputs.Current.Should()
-                    .Contain($"Saving variable 'Octopus.Action[\"\"].Output.TerraformValueOutputs[\"url\"]' with the value only of 'https://{bucketName}.s3.amazonaws.com/test.txt'");
+                    .Contain($"Saving variable 'Octopus.Action[].Output.TerraformValueOutputs[url]' with the value only of 'https://{bucketName}.s3.amazonaws.com/test.txt'");
 
                 string fileData;
                 using (var client = new HttpClient())
@@ -382,7 +382,7 @@ namespace Calamari.Terraform.Tests
             {
                 outputs.MoveNext();
                 outputs.Current.Should()
-                    .Contain("Saving variable 'Octopus.Action[\"\"].Output.TerraformPlanDetailedExitCode' with the detailed exit code of the plan, with value '2'");
+                    .Contain("Saving variable 'Octopus.Action[].Output.TerraformPlanDetailedExitCode' with the detailed exit code of the plan, with value '2'");
 
                 outputs.MoveNext();
                 outputs.Current.Should()
@@ -390,7 +390,7 @@ namespace Calamari.Terraform.Tests
 
                 outputs.MoveNext();
                 outputs.Current.Should()
-                    .Contain("Saving variable 'Octopus.Action[\"\"].Output.TerraformPlanDetailedExitCode' with the detailed exit code of the plan, with value '0'");
+                    .Contain("Saving variable 'Octopus.Action[].Output.TerraformPlanDetailedExitCode' with the detailed exit code of the plan, with value '0'");
             }
         }
 

--- a/source/Calamari.Terraform/ApplyCommand.cs
+++ b/source/Calamari.Terraform/ApplyCommand.cs
@@ -52,11 +52,11 @@ namespace Calamari.Terraform
                     }
 
                     log.Info(
-                        $"Saving {(isSensitive ? "sensitive" : String.Empty)}variable 'Octopus.Action[\"{deployment.Variables["Octopus.Action.StepName"]}\"].Output.TerraformJsonOutputs[\"{name}\"]' with the JSON value only of '{json}'");
+                        $"Saving {(isSensitive ? "sensitive" : String.Empty)}variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.TerraformJsonOutputs[{name}]' with the JSON value only of '{json}'");
                     if (value != null)
                     {
                         log.Info(
-                            $"Saving {(isSensitive ? "sensitive" : String.Empty)}variable 'Octopus.Action[\"{deployment.Variables["Octopus.Action.StepName"]}\"].Output.TerraformValueOutputs[\"{name}\"]' with the value only of '{value}'");
+                            $"Saving {(isSensitive ? "sensitive" : String.Empty)}variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.TerraformValueOutputs[{name}]' with the value only of '{value}'");
                     }
                 }
             }

--- a/source/Calamari.Terraform/PlanCommand.cs
+++ b/source/Calamari.Terraform/PlanCommand.cs
@@ -43,12 +43,12 @@ namespace Calamari.Terraform
                 }
 
                 log.Info(
-                    $"Saving variable 'Octopus.Action[\"{deployment.Variables["Octopus.Action.StepName"]}\"].Output.{TerraformSpecialVariables.Action.Terraform.PlanDetailedExitCode}' with the detailed exit code of the plan, with value '{resultCode}'.");
+                    $"Saving variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.{TerraformSpecialVariables.Action.Terraform.PlanDetailedExitCode}' with the detailed exit code of the plan, with value '{resultCode}'.");
                 log.SetOutputVariable(TerraformSpecialVariables.Action.Terraform.PlanDetailedExitCode, resultCode.ToString(), deployment.Variables);
             }
 
             log.Info(
-                $"Saving variable 'Octopus.Action[\"{deployment.Variables["Octopus.Action.StepName"]}\"].Output.{TerraformSpecialVariables.Action.Terraform.PlanOutput}' with the details of the plan");
+                $"Saving variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.{TerraformSpecialVariables.Action.Terraform.PlanOutput}' with the details of the plan");
             log.SetOutputVariable(TerraformSpecialVariables.Action.Terraform.PlanOutput, results, deployment.Variables);
         }
     }


### PR DESCRIPTION
Hi,

This PR removes quotes around octopus variable dictionary index names in Terraform plan and apply output, to hopefully avoid other people spending way too long trying to figure out why the variables they copy/pasted aren't being substituted 😢