### PR TITLE
Fluentvalidation tests for terraform

### DIFF
--- a/source/Sashimi.Terraform.Tests/TerraformValidatorFixture.cs
+++ b/source/Sashimi.Terraform.Tests/TerraformValidatorFixture.cs
@@ -18,16 +18,22 @@ namespace Sashimi.Terraform.Tests
     public class TerraformValidatorFixture
     {
         TerraformValidator? validator;
-        
+        IContainer? container;
+
         [SetUp]
-        public void Setup() {
+        public void Setup()
+        {
             var builder = new ContainerBuilder();
             builder.RegisterModule<TerraformModule>();
             builder.RegisterModule<ServerModule>();
-            using (var container = builder.Build())
-            {
-                validator = new TerraformValidator(container.Resolve<ICloudTemplateHandlerFactory>());
-            }
+            container = builder.Build();
+            validator = new TerraformValidator(container.Resolve<ICloudTemplateHandlerFactory>());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            container?.Dispose();
         }
 
         [Test]
@@ -35,29 +41,35 @@ namespace Sashimi.Terraform.Tests
         [TestCase(TerraformActionTypes.Destroy)]
         public void Should_have_error_when_empty_inline_template(string actionType)
         {
-            var result = validator.TestValidate(new DeploymentActionValidationContext(actionType,
+            var context = new DeploymentActionValidationContext(actionType,
                 new Dictionary<string, string>
                 {
                     {KnownVariables.Action.Script.ScriptSource, KnownVariableValues.Action.Script.ScriptSource.Inline}
-                }, new List<PackageReference>()));
+                }, new List<PackageReference>());
+            
+            var result = validator.TestValidate(context);
+            
             result.IsValid.Should().BeFalse();
-            result.Errors.Single().PropertyName.Should().Be(TerraformSpecialVariables.Action.Terraform.Template);
+            result.Errors.Should().ContainSingle().Which.PropertyName.Should().Be(TerraformSpecialVariables.Action.Terraform.Template);
         }
-        
+
         [Test]
         [TestCase(TerraformActionTypes.Apply)]
         [TestCase(TerraformActionTypes.Destroy)]
         public void Should_not_have_error_when_has_inline_template(string actionType)
         {
-            var result = validator.TestValidate(new DeploymentActionValidationContext(actionType,
+            var context = new DeploymentActionValidationContext(actionType,
                 new Dictionary<string, string>
                 {
                     {KnownVariables.Action.Script.ScriptSource, KnownVariableValues.Action.Script.ScriptSource.Inline},
                     {TerraformSpecialVariables.Action.Terraform.Template, "{}"}
-                }, new List<PackageReference>()));
+                }, new List<PackageReference>());
+            
+            var result = validator.TestValidate(context);
+            
             result.IsValid.Should().BeTrue();
         }
-        
+
         [Test]
         [TestCase(TerraformActionTypes.Apply)]
         [TestCase(TerraformActionTypes.Destroy)]
@@ -74,17 +86,23 @@ namespace Sashimi.Terraform.Tests
             variable ""map"" {
                 type = ""map""
             }";
-            var result = validator.TestValidate(new DeploymentActionValidationContext(actionType,
+            var context = new DeploymentActionValidationContext(actionType,
                 new Dictionary<string, string>
                 {
                     {KnownVariables.Action.Script.ScriptSource, KnownVariableValues.Action.Script.ScriptSource.Inline},
                     {TerraformSpecialVariables.Action.Terraform.Template, template},
-                    {TerraformSpecialVariables.Action.Terraform.TemplateParameters, @"{""list"": ""invalid list"", ""map"": ""invalid map""}"}
-                }, new List<PackageReference>()));
+                    {
+                        TerraformSpecialVariables.Action.Terraform.TemplateParameters,
+                        @"{""list"": ""invalid list"", ""map"": ""invalid map""}"
+                    }
+                }, new List<PackageReference>());
+            
+            var result = validator.TestValidate(context);
+            
             result.IsValid.Should().BeFalse();
-            result.Errors.Single().PropertyName.Should().Be("Properties");
+            result.Errors.Should().ContainSingle().Which.PropertyName.Should().Be("Properties");
         }
-        
+
         [Test]
         [TestCase(TerraformActionTypes.Apply)]
         [TestCase(TerraformActionTypes.Destroy)]
@@ -101,85 +119,109 @@ namespace Sashimi.Terraform.Tests
             variable ""map"" {
                 type = ""map""
             }";
-            var result = validator.TestValidate(new DeploymentActionValidationContext(actionType,
+            var context = new DeploymentActionValidationContext(actionType,
                 new Dictionary<string, string>
                 {
                     {KnownVariables.Action.Script.ScriptSource, KnownVariableValues.Action.Script.ScriptSource.Inline},
                     {TerraformSpecialVariables.Action.Terraform.Template, template},
-                    {TerraformSpecialVariables.Action.Terraform.TemplateParameters, "{\"map\":\"{foo = \\\"bar\\\", baz = \\\"qux\\\"}\"}"}
-                }, new List<PackageReference>()));
+                    {
+                        TerraformSpecialVariables.Action.Terraform.TemplateParameters,
+                        "{\"map\":\"{foo = \\\"bar\\\", baz = \\\"qux\\\"}\"}"
+                    }
+                }, new List<PackageReference>());
+            
+            var result = validator.TestValidate(context);
+            
             result.IsValid.Should().BeTrue();
         }
-        
+
         [Test]
         [TestCase(TerraformActionTypes.Apply)]
         [TestCase(TerraformActionTypes.Destroy)]
         public void Should_have_error_when_package_template_not_specified(string actionType)
         {
-            var result = validator.TestValidate(new DeploymentActionValidationContext(actionType,
+            var context = new DeploymentActionValidationContext(actionType,
                 new Dictionary<string, string>
                 {
                     {KnownVariables.Action.Script.ScriptSource, KnownVariableValues.Action.Script.ScriptSource.Package},
-                }, new List<PackageReference>()));
+                }, new List<PackageReference>());
+            
+            var result = validator.TestValidate(context);
+            
             result.IsValid.Should().BeFalse();
-            result.Errors.Single().PropertyName.Should().Be("Packages");
+            result.Errors.Should().ContainSingle().Which.PropertyName.Should().Be("Packages");
         }
-        
+
         [Test]
         [TestCase(TerraformActionTypes.Apply)]
         [TestCase(TerraformActionTypes.Destroy)]
         public void Should_have_no_error_when_package_template_is_specified(string actionType)
         {
-            var result = validator.TestValidate(new DeploymentActionValidationContext(actionType,
+            var context = new DeploymentActionValidationContext(actionType,
                 new Dictionary<string, string>
                 {
                     {KnownVariables.Action.Script.ScriptSource, KnownVariableValues.Action.Script.ScriptSource.Package},
-                }, new List<PackageReference> { new PackageReference("packageId", "feedId")}));
+                }, new List<PackageReference> {new PackageReference("packageId", "feedId")});
+            
+            var result = validator.TestValidate(context);
+            
             result.IsValid.Should().BeTrue();
         }
-        
+
         [Test]
         public void Should_have_error_when_azure_account_not_specified()
         {
-            var result = validator.TestValidate(new DeploymentActionValidationContext(TerraformActionTypes.Plan,
+            var context = new DeploymentActionValidationContext(TerraformActionTypes.Plan,
                 new Dictionary<string, string>
                 {
                     {TerraformSpecialVariables.Action.Terraform.AzureAccount, Boolean.TrueString},
-                }, new List<PackageReference>()));
+                }, new List<PackageReference>());
+            
+            var result = validator.TestValidate(context);
+            
             result.IsValid.Should().BeFalse();
-            result.Errors.Single().PropertyName.Should().Be("Octopus.Action.AzureAccount.Variable");
+            result.Errors.Should().ContainSingle().Which.PropertyName.Should().Be("Octopus.Action.AzureAccount.Variable");
         }
-        
+
         [Test]
         public void Should_have_no_error_when_azure_account_is_specified()
         {
-            var result = validator.TestValidate(new DeploymentActionValidationContext(TerraformActionTypes.Plan,
+            var context = new DeploymentActionValidationContext(TerraformActionTypes.Plan,
                 new Dictionary<string, string>
                 {
                     {TerraformSpecialVariables.Action.Terraform.AzureAccount, Boolean.TrueString},
                     {"Octopus.Action.AzureAccount.Variable", "Myvariable"},
-                }, new List<PackageReference>()));
+                }, new List<PackageReference>());
+            
+            var result = validator.TestValidate(context);
+            
             result.IsValid.Should().BeTrue();
         }
-        
+
         [Test]
         public void Should_have_error_when_aws_account_has_no_roles_specified()
         {
-            var result = validator.TestValidate(new DeploymentActionValidationContext(TerraformActionTypes.Plan,
+            var context = new DeploymentActionValidationContext(TerraformActionTypes.Plan,
                 new Dictionary<string, string>
                 {
                     {TerraformSpecialVariables.Action.Terraform.ManagedAccount, TerraformSpecialVariables.AwsAccount},
                     {TerraformSpecialVariables.Action.Aws.AssumeRole, Boolean.TrueString},
                     {TerraformSpecialVariables.Action.Aws.AwsRegion, "MyRegion"},
-                    {TerraformSpecialVariables.Action.Aws.AccountVariable, "MyVariable"},}, new List<PackageReference>()));
+                    {TerraformSpecialVariables.Action.Aws.AccountVariable, "MyVariable"},
+                }, new List<PackageReference>());
+            
+            var result = validator.TestValidate(context);
+            
             result.IsValid.Should().BeFalse();
-            result.Errors.Select(_ => _.PropertyName).Should().Equal(TerraformSpecialVariables.Action.Aws.AssumedRoleArn, TerraformSpecialVariables.Action.Aws.AssumedRoleSession);
+            result.Errors.Select(_ => _.PropertyName).Should().Equal(
+                TerraformSpecialVariables.Action.Aws.AssumedRoleArn,
+                TerraformSpecialVariables.Action.Aws.AssumedRoleSession);
         }
-        
+
         [Test]
         public void Should_have_no_error_when_aws_account_has_roles_specified()
         {
-            var result = validator.TestValidate(new DeploymentActionValidationContext(TerraformActionTypes.Plan,
+            var context = new DeploymentActionValidationContext(TerraformActionTypes.Plan,
                 new Dictionary<string, string>
                 {
                     {TerraformSpecialVariables.Action.Terraform.ManagedAccount, TerraformSpecialVariables.AwsAccount},
@@ -188,63 +230,78 @@ namespace Sashimi.Terraform.Tests
                     {TerraformSpecialVariables.Action.Aws.AccountVariable, "MyVariable"},
                     {TerraformSpecialVariables.Action.Aws.AssumedRoleArn, "RoleArn"},
                     {TerraformSpecialVariables.Action.Aws.AssumedRoleSession, "RoleSession"},
-                }, new List<PackageReference>()));
+                }, new List<PackageReference>());
+            
+            var result = validator.TestValidate(context);
+            
             result.IsValid.Should().BeTrue();
         }
-        
+
         [Test]
         public void Should_have_error_when_aws_account_with_no_region_specified()
         {
-            var result = validator.TestValidate(new DeploymentActionValidationContext(TerraformActionTypes.Plan,
+            var context = new DeploymentActionValidationContext(TerraformActionTypes.Plan,
                 new Dictionary<string, string>
                 {
                     {TerraformSpecialVariables.Action.Terraform.ManagedAccount, TerraformSpecialVariables.AwsAccount},
                     {TerraformSpecialVariables.Action.Aws.AssumeRole, Boolean.FalseString},
                     {TerraformSpecialVariables.Action.Aws.AccountVariable, "MyVariable"},
-                }, new List<PackageReference>()));
+                }, new List<PackageReference>());
+            
+            var result = validator.TestValidate(context);
+            
             result.IsValid.Should().BeFalse();
-            result.Errors.Single().PropertyName.Should().Be(TerraformSpecialVariables.Action.Aws.AwsRegion);
+            result.Errors.Should().ContainSingle().Which.PropertyName.Should().Be(TerraformSpecialVariables.Action.Aws.AwsRegion);
         }
-        
+
         [Test]
         public void Should_have_no_error_when_aws_account_has_region_specified()
         {
-            var result = validator.TestValidate(new DeploymentActionValidationContext(TerraformActionTypes.Plan,
+            var context = new DeploymentActionValidationContext(TerraformActionTypes.Plan,
                 new Dictionary<string, string>
                 {
                     {TerraformSpecialVariables.Action.Terraform.ManagedAccount, TerraformSpecialVariables.AwsAccount},
                     {TerraformSpecialVariables.Action.Aws.AssumeRole, Boolean.FalseString},
                     {TerraformSpecialVariables.Action.Aws.AwsRegion, "MyRegion"},
                     {TerraformSpecialVariables.Action.Aws.AccountVariable, "MyVariable"},
-                }, new List<PackageReference>()));
+                }, new List<PackageReference>());
+            
+            var result = validator.TestValidate(context);
+            
             result.IsValid.Should().BeTrue();
         }
-        
+
         [Test]
         public void Should_have_error_when_aws_account_with_no_account_variable_specified()
         {
-            var result = validator.TestValidate(new DeploymentActionValidationContext(TerraformActionTypes.Plan,
+            var context = new DeploymentActionValidationContext(TerraformActionTypes.Plan,
                 new Dictionary<string, string>
                 {
                     {TerraformSpecialVariables.Action.Terraform.ManagedAccount, TerraformSpecialVariables.AwsAccount},
                     {TerraformSpecialVariables.Action.Aws.AssumeRole, Boolean.FalseString},
                     {TerraformSpecialVariables.Action.Aws.AwsRegion, "MyRegion"},
-                }, new List<PackageReference>()));
+                }, new List<PackageReference>());
+            
+            var result = validator.TestValidate(context);
+            
             result.IsValid.Should().BeFalse();
-            result.Errors.Single().PropertyName.Should().Be(TerraformSpecialVariables.Action.Aws.AccountVariable);
+            result.Errors.Should().ContainSingle().Which.PropertyName.Should().Be(TerraformSpecialVariables.Action.Aws.AccountVariable);
         }
-        
+
         [Test]
         public void Should_have_no_error_when_aws_account_with_account_variable_specified()
         {
-            var result = validator.TestValidate(new DeploymentActionValidationContext(TerraformActionTypes.Plan,
+            var context = new DeploymentActionValidationContext(TerraformActionTypes.Plan,
                 new Dictionary<string, string>
                 {
                     {TerraformSpecialVariables.Action.Terraform.ManagedAccount, TerraformSpecialVariables.AwsAccount},
                     {TerraformSpecialVariables.Action.Aws.AssumeRole, Boolean.FalseString},
                     {TerraformSpecialVariables.Action.Aws.AwsRegion, "MyRegion"},
                     {TerraformSpecialVariables.Action.Aws.AccountVariable, "MyVariable"},
-                }, new List<PackageReference>()));
+                }, new List<PackageReference>());
+            
+            var result = validator.TestValidate(context);
+            
             result.IsValid.Should().BeTrue();
         }
     }

--- a/source/Sashimi.Terraform.Tests/TerraformValidatorFixture.cs
+++ b/source/Sashimi.Terraform.Tests/TerraformValidatorFixture.cs
@@ -1,0 +1,251 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autofac;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using NUnit.Framework;
+using Octopus.Server.Extensibility.HostServices.Model;
+using Sashimi.Server.Contracts;
+using Sashimi.Server.Contracts.ActionHandlers.Validation;
+using Sashimi.Server.Contracts.CloudTemplates;
+using Sashimi.Terraform.Validation;
+using Sashimi.Tests.Shared.Server;
+
+namespace Sashimi.Terraform.Tests
+{
+    [TestFixture]
+    public class TerraformValidatorFixture
+    {
+        TerraformValidator? validator;
+        
+        [SetUp]
+        public void Setup() {
+            var builder = new ContainerBuilder();
+            builder.RegisterModule<TerraformModule>();
+            builder.RegisterModule<ServerModule>();
+            using (var container = builder.Build())
+            {
+                validator = new TerraformValidator(container.Resolve<ICloudTemplateHandlerFactory>());
+            }
+        }
+
+        [Test]
+        [TestCase(TerraformActionTypes.Apply)]
+        [TestCase(TerraformActionTypes.Destroy)]
+        public void Should_have_error_when_empty_inline_template(string actionType)
+        {
+            var result = validator.TestValidate(new DeploymentActionValidationContext(actionType,
+                new Dictionary<string, string>
+                {
+                    {KnownVariables.Action.Script.ScriptSource, KnownVariableValues.Action.Script.ScriptSource.Inline}
+                }, new List<PackageReference>()));
+            result.IsValid.Should().BeFalse();
+            result.Errors.Single().PropertyName.Should().Be(TerraformSpecialVariables.Action.Terraform.Template);
+        }
+        
+        [Test]
+        [TestCase(TerraformActionTypes.Apply)]
+        [TestCase(TerraformActionTypes.Destroy)]
+        public void Should_not_have_error_when_has_inline_template(string actionType)
+        {
+            var result = validator.TestValidate(new DeploymentActionValidationContext(actionType,
+                new Dictionary<string, string>
+                {
+                    {KnownVariables.Action.Script.ScriptSource, KnownVariableValues.Action.Script.ScriptSource.Inline},
+                    {TerraformSpecialVariables.Action.Terraform.Template, "{}"}
+                }, new List<PackageReference>()));
+            result.IsValid.Should().BeTrue();
+        }
+        
+        [Test]
+        [TestCase(TerraformActionTypes.Apply)]
+        [TestCase(TerraformActionTypes.Destroy)]
+        public void Should_have_error_when_inline_template_with_invalid_inline_variables(string actionType)
+        {
+            var template = @"variable ""test"" {
+                type = ""string""
+            }
+
+            variable ""list"" {
+                type = ""list""
+            }
+
+            variable ""map"" {
+                type = ""map""
+            }";
+            var result = validator.TestValidate(new DeploymentActionValidationContext(actionType,
+                new Dictionary<string, string>
+                {
+                    {KnownVariables.Action.Script.ScriptSource, KnownVariableValues.Action.Script.ScriptSource.Inline},
+                    {TerraformSpecialVariables.Action.Terraform.Template, template},
+                    {TerraformSpecialVariables.Action.Terraform.TemplateParameters, @"{""list"": ""invalid list"", ""map"": ""invalid map""}"}
+                }, new List<PackageReference>()));
+            result.IsValid.Should().BeFalse();
+            result.Errors.Single().PropertyName.Should().Be("Properties");
+        }
+        
+        [Test]
+        [TestCase(TerraformActionTypes.Apply)]
+        [TestCase(TerraformActionTypes.Destroy)]
+        public void Should_have_no_error_when_inline_template_with_valid_inline_variables(string actionType)
+        {
+            var template = @"variable ""test"" {
+                type = ""string""
+            }
+
+            variable ""list"" {
+                type = ""list""
+            }
+
+            variable ""map"" {
+                type = ""map""
+            }";
+            var result = validator.TestValidate(new DeploymentActionValidationContext(actionType,
+                new Dictionary<string, string>
+                {
+                    {KnownVariables.Action.Script.ScriptSource, KnownVariableValues.Action.Script.ScriptSource.Inline},
+                    {TerraformSpecialVariables.Action.Terraform.Template, template},
+                    {TerraformSpecialVariables.Action.Terraform.TemplateParameters, "{\"map\":\"{foo = \\\"bar\\\", baz = \\\"qux\\\"}\"}"}
+                }, new List<PackageReference>()));
+            result.IsValid.Should().BeTrue();
+        }
+        
+        [Test]
+        [TestCase(TerraformActionTypes.Apply)]
+        [TestCase(TerraformActionTypes.Destroy)]
+        public void Should_have_error_when_package_template_not_specified(string actionType)
+        {
+            var result = validator.TestValidate(new DeploymentActionValidationContext(actionType,
+                new Dictionary<string, string>
+                {
+                    {KnownVariables.Action.Script.ScriptSource, KnownVariableValues.Action.Script.ScriptSource.Package},
+                }, new List<PackageReference>()));
+            result.IsValid.Should().BeFalse();
+            result.Errors.Single().PropertyName.Should().Be("Packages");
+        }
+        
+        [Test]
+        [TestCase(TerraformActionTypes.Apply)]
+        [TestCase(TerraformActionTypes.Destroy)]
+        public void Should_have_no_error_when_package_template_is_specified(string actionType)
+        {
+            var result = validator.TestValidate(new DeploymentActionValidationContext(actionType,
+                new Dictionary<string, string>
+                {
+                    {KnownVariables.Action.Script.ScriptSource, KnownVariableValues.Action.Script.ScriptSource.Package},
+                }, new List<PackageReference> { new PackageReference("packageId", "feedId")}));
+            result.IsValid.Should().BeTrue();
+        }
+        
+        [Test]
+        public void Should_have_error_when_azure_account_not_specified()
+        {
+            var result = validator.TestValidate(new DeploymentActionValidationContext(TerraformActionTypes.Plan,
+                new Dictionary<string, string>
+                {
+                    {TerraformSpecialVariables.Action.Terraform.AzureAccount, Boolean.TrueString},
+                }, new List<PackageReference>()));
+            result.IsValid.Should().BeFalse();
+            result.Errors.Single().PropertyName.Should().Be("Octopus.Action.AzureAccount.Variable");
+        }
+        
+        [Test]
+        public void Should_have_no_error_when_azure_account_is_specified()
+        {
+            var result = validator.TestValidate(new DeploymentActionValidationContext(TerraformActionTypes.Plan,
+                new Dictionary<string, string>
+                {
+                    {TerraformSpecialVariables.Action.Terraform.AzureAccount, Boolean.TrueString},
+                    {"Octopus.Action.AzureAccount.Variable", "Myvariable"},
+                }, new List<PackageReference>()));
+            result.IsValid.Should().BeTrue();
+        }
+        
+        [Test]
+        public void Should_have_error_when_aws_account_has_no_roles_specified()
+        {
+            var result = validator.TestValidate(new DeploymentActionValidationContext(TerraformActionTypes.Plan,
+                new Dictionary<string, string>
+                {
+                    {TerraformSpecialVariables.Action.Terraform.ManagedAccount, TerraformSpecialVariables.AwsAccount},
+                    {TerraformSpecialVariables.Action.Aws.AssumeRole, Boolean.TrueString},
+                    {TerraformSpecialVariables.Action.Aws.AwsRegion, "MyRegion"},
+                    {TerraformSpecialVariables.Action.Aws.AccountVariable, "MyVariable"},}, new List<PackageReference>()));
+            result.IsValid.Should().BeFalse();
+            result.Errors.Select(_ => _.PropertyName).Should().Equal(TerraformSpecialVariables.Action.Aws.AssumedRoleArn, TerraformSpecialVariables.Action.Aws.AssumedRoleSession);
+        }
+        
+        [Test]
+        public void Should_have_no_error_when_aws_account_has_roles_specified()
+        {
+            var result = validator.TestValidate(new DeploymentActionValidationContext(TerraformActionTypes.Plan,
+                new Dictionary<string, string>
+                {
+                    {TerraformSpecialVariables.Action.Terraform.ManagedAccount, TerraformSpecialVariables.AwsAccount},
+                    {TerraformSpecialVariables.Action.Aws.AssumeRole, Boolean.TrueString},
+                    {TerraformSpecialVariables.Action.Aws.AwsRegion, "MyRegion"},
+                    {TerraformSpecialVariables.Action.Aws.AccountVariable, "MyVariable"},
+                    {TerraformSpecialVariables.Action.Aws.AssumedRoleArn, "RoleArn"},
+                    {TerraformSpecialVariables.Action.Aws.AssumedRoleSession, "RoleSession"},
+                }, new List<PackageReference>()));
+            result.IsValid.Should().BeTrue();
+        }
+        
+        [Test]
+        public void Should_have_error_when_aws_account_with_no_region_specified()
+        {
+            var result = validator.TestValidate(new DeploymentActionValidationContext(TerraformActionTypes.Plan,
+                new Dictionary<string, string>
+                {
+                    {TerraformSpecialVariables.Action.Terraform.ManagedAccount, TerraformSpecialVariables.AwsAccount},
+                    {TerraformSpecialVariables.Action.Aws.AssumeRole, Boolean.FalseString},
+                    {TerraformSpecialVariables.Action.Aws.AccountVariable, "MyVariable"},
+                }, new List<PackageReference>()));
+            result.IsValid.Should().BeFalse();
+            result.Errors.Single().PropertyName.Should().Be(TerraformSpecialVariables.Action.Aws.AwsRegion);
+        }
+        
+        [Test]
+        public void Should_have_no_error_when_aws_account_has_region_specified()
+        {
+            var result = validator.TestValidate(new DeploymentActionValidationContext(TerraformActionTypes.Plan,
+                new Dictionary<string, string>
+                {
+                    {TerraformSpecialVariables.Action.Terraform.ManagedAccount, TerraformSpecialVariables.AwsAccount},
+                    {TerraformSpecialVariables.Action.Aws.AssumeRole, Boolean.FalseString},
+                    {TerraformSpecialVariables.Action.Aws.AwsRegion, "MyRegion"},
+                    {TerraformSpecialVariables.Action.Aws.AccountVariable, "MyVariable"},
+                }, new List<PackageReference>()));
+            result.IsValid.Should().BeTrue();
+        }
+        
+        [Test]
+        public void Should_have_error_when_aws_account_with_no_account_variable_specified()
+        {
+            var result = validator.TestValidate(new DeploymentActionValidationContext(TerraformActionTypes.Plan,
+                new Dictionary<string, string>
+                {
+                    {TerraformSpecialVariables.Action.Terraform.ManagedAccount, TerraformSpecialVariables.AwsAccount},
+                    {TerraformSpecialVariables.Action.Aws.AssumeRole, Boolean.FalseString},
+                    {TerraformSpecialVariables.Action.Aws.AwsRegion, "MyRegion"},
+                }, new List<PackageReference>()));
+            result.IsValid.Should().BeFalse();
+            result.Errors.Single().PropertyName.Should().Be(TerraformSpecialVariables.Action.Aws.AccountVariable);
+        }
+        
+        [Test]
+        public void Should_have_no_error_when_aws_account_with_account_variable_specified()
+        {
+            var result = validator.TestValidate(new DeploymentActionValidationContext(TerraformActionTypes.Plan,
+                new Dictionary<string, string>
+                {
+                    {TerraformSpecialVariables.Action.Terraform.ManagedAccount, TerraformSpecialVariables.AwsAccount},
+                    {TerraformSpecialVariables.Action.Aws.AssumeRole, Boolean.FalseString},
+                    {TerraformSpecialVariables.Action.Aws.AwsRegion, "MyRegion"},
+                    {TerraformSpecialVariables.Action.Aws.AccountVariable, "MyVariable"},
+                }, new List<PackageReference>()));
+            result.IsValid.Should().BeTrue();
+        }
+    }
+}

--- a/source/Sashimi.Terraform/Validation/TerraformDeploymentActionValidation.cs
+++ b/source/Sashimi.Terraform/Validation/TerraformDeploymentActionValidation.cs
@@ -1,0 +1,21 @@
+﻿using FluentValidation;
+using Sashimi.Server.Contracts.ActionHandlers.Validation;
+using Sashimi.Server.Contracts.CloudTemplates;
+
+namespace Sashimi.Terraform.Validation
+{
+    public class TerraformDeploymentActionValidation : IDeploymentActionValidator
+    {
+        readonly ICloudTemplateHandlerFactory cloudTemplateHandlerFactory;
+
+        public TerraformDeploymentActionValidation(ICloudTemplateHandlerFactory cloudTemplateHandlerFactory)
+        {
+            this.cloudTemplateHandlerFactory = cloudTemplateHandlerFactory;
+        }
+        
+        public void AddDeploymentValidationRule(AbstractValidator<DeploymentActionValidationContext> validator)
+        {
+            validator.Include(new TerraformValidator(cloudTemplateHandlerFactory));
+        }
+    }
+}

--- a/source/Sashimi.Terraform/Validation/TerraformValidator.cs
+++ b/source/Sashimi.Terraform/Validation/TerraformValidator.cs
@@ -157,7 +157,7 @@ namespace Sashimi.Terraform.Validation
             return invalidProperties;
         }
         
-        public static bool IsTemplateFromPackage(IReadOnlyDictionary<string, string> properties)
+        static bool IsTemplateFromPackage(IReadOnlyDictionary<string, string> properties)
         {
             return properties.TryGetValue(KnownVariables.Action.Script.ScriptSource, out var scriptSource) &&
                    scriptSource == KnownVariableValues.Action.Script.ScriptSource.Package;

--- a/source/Server.Contracts/KnownVariableValues.cs
+++ b/source/Server.Contracts/KnownVariableValues.cs
@@ -9,6 +9,7 @@
                 public static class ScriptSource
                 {
                     public static readonly string Package = "Package";
+                    public static readonly string Inline = "Inline";
                 }
             }
         }


### PR DESCRIPTION
I just had to do a little refactor to make testing of `AbstractValidator<T>` easier.
So the secret sauce if to refactor the validation impls of `IDeploymentActionValidator` into classes derived from `AbstractValidator<T>`, and then all we need to do is "include" them, eg:

```c#
public class XActionValidation : IDeploymentActionValidator
{
    public void AddDeploymentValidationRule(AbstractValidator<DeploymentActionValidationContext> validator)
    {
        validator.Include(new MyValidator());
    }
}
```
and then `MyValidator` is a simple:

```c#
public class MyValidator : AbstractValidator<DeploymentActionValidationContext>
{
    public MyValidator()
    {
        RuleFor(a => a.Properties)...
    }
}
```