### PR TITLE
Adding more tests to Terraform

### DIFF
--- a/source/Sashimi.Terraform.Tests/ActionHandlersFixture.cs
+++ b/source/Sashimi.Terraform.Tests/ActionHandlersFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -217,13 +217,25 @@ namespace Sashimi.Terraform.Tests
                     _.Variables.Add("Octopus.Action.StepName", "Step Name");
                     _.Variables.Add("Should_Be_Substituted", "Hello World");
                     _.Variables.Add("Should_Be_Substituted_in_txt", "Hello World from text");
-                }, "WithVariablesSubstitution")
-                .Should()
-                .Contain("Octopus.Action[\"Step Name\"].Output.TerraformValueOutputs[\"my_output\"]' with the value only of 'Hello World'")
-                .And
-                .Contain("Octopus.Action[\"Step Name\"].Output.TerraformValueOutputs[\"my_output_from_txt_file\"]' with the value only of 'Hello World from text'");
+                }, "WithVariablesSubstitution",
+                result =>
+                {
+                    result.OutputVariables
+                        .ContainsKey("TerraformValueOutputs[my_output]")
+                        .Should().BeTrue();
+                    result.OutputVariables["TerraformValueOutputs[my_output]"].Value
+                        .Should()
+                        .Be("Hello World");
+                    result.OutputVariables
+                        .ContainsKey("TerraformValueOutputs[my_output_from_txt_file]")
+                        .Should().BeTrue();
+                    result.OutputVariables["TerraformValueOutputs[my_output_from_txt_file]"]
+                        .Value
+                        .Should()
+                        .Be("Hello World from text");
+                });
         }
-        
+
         [Test]
         public void EnableNoMatchWarningIsNotSet()
         {
@@ -276,8 +288,13 @@ namespace Sashimi.Terraform.Tests
         [TestCase(typeof(TerraformPlanDestroyActionHandler))]
         public void TerraformPlanOutput(Type commandType)
         {
-            ExecuteAndReturnLogOutput(commandType, _ => { _.Variables.Add("Octopus.Action.StepName", "Step Name"); }, "Simple")
-                .Should().Contain("Octopus.Action[\"Step Name\"].Output.TerraformPlanOutput");
+            ExecuteAndReturnLogOutput(commandType, _ => { _.Variables.Add("Octopus.Action.StepName", "Step Name"); }, "Simple",
+                    result =>
+                    {
+                        result.OutputVariables
+                            .ContainsKey("TerraformPlanOutput")
+                            .Should().BeTrue();
+                    });
         }
 
         [Test]
@@ -312,16 +329,15 @@ namespace Sashimi.Terraform.Tests
                 _.Variables.Add(TerraformSpecialVariables.Action.Terraform.AzureManagedAccount, Boolean.TrueString);
             }
 
-            using (var outputs = ExecuteAndReturnLogOutput(PopulateVariables, "Azure", null, typeof(TerraformPlanActionHandler),
+            using (var outputs = ExecuteAndReturnLogOutput(PopulateVariables, "Azure", typeof(TerraformPlanActionHandler),
                 typeof(TerraformApplyActionHandler), typeof(TerraformDestroyActionHandler)).GetEnumerator())
             {
                 outputs.MoveNext();
-                outputs.Current.Should()
-                    .Contain("Octopus.Action[\"\"].Output.TerraformPlanOutput");
+                outputs.Current.OutputVariables.ContainsKey("TerraformPlanOutput").Should().BeTrue();
 
                 outputs.MoveNext();
-                outputs.Current.Should()
-                    .Contain($"Saving variable 'Octopus.Action[\"\"].Output.TerraformValueOutputs[\"url\"]' with the value only of '{appName}.azurewebsites.net'");
+                outputs.Current.OutputVariables.ContainsKey("TerraformValueOutputs[url]").Should().BeTrue();
+                outputs.Current.OutputVariables["TerraformValueOutputs[url]"].Value.Should().Be($"{appName}.azurewebsites.net");
 
                 using (var client = new HttpClient())
                 {
@@ -333,7 +349,7 @@ namespace Sashimi.Terraform.Tests
                 }
 
                 outputs.MoveNext();
-                outputs.Current.Should()
+                outputs.Current.FullLog.Should()
                     .Contain("destroy -force -no-color");
             }
         }
@@ -355,15 +371,14 @@ namespace Sashimi.Terraform.Tests
                 _.Variables.Add(TerraformSpecialVariables.Action.Terraform.AWSManagedAccount, "AWS");
             }
 
-            using (var outputs = ExecuteAndReturnLogOutput(PopulateVariables, "AWS", null, typeof(TerraformPlanActionHandler), typeof(TerraformApplyActionHandler), typeof(TerraformDestroyActionHandler)).GetEnumerator())
+            using (var outputs = ExecuteAndReturnLogOutput(PopulateVariables, "AWS", typeof(TerraformPlanActionHandler), typeof(TerraformApplyActionHandler), typeof(TerraformDestroyActionHandler)).GetEnumerator())
             {
                 outputs.MoveNext();
-                outputs.Current.Should()
-                    .Contain("Octopus.Action[\"\"].Output.TerraformPlanOutput");
+                outputs.Current.OutputVariables.ContainsKey("TerraformPlanOutput").Should().BeTrue();
 
                 outputs.MoveNext();
-                outputs.Current.Should()
-                    .Contain($"Saving variable 'Octopus.Action[\"\"].Output.TerraformValueOutputs[\"url\"]' with the value only of 'https://{bucketName}.s3.amazonaws.com/test.txt'");
+                outputs.Current.OutputVariables.ContainsKey("TerraformValueOutputs[url]").Should().BeTrue();
+                outputs.Current.OutputVariables["TerraformValueOutputs[url]"].Value.Should().Be($"https://{bucketName}.s3.amazonaws.com/test.txt");
 
                 string fileData;
                 using (var client = new HttpClient())
@@ -374,7 +389,7 @@ namespace Sashimi.Terraform.Tests
                 fileData.Should().Be("Hello World from AWS");
 
                 outputs.MoveNext();
-                outputs.Current.Should()
+                outputs.Current.FullLog.Should()
                     .Contain("destroy -force -no-color");
             }
         }
@@ -389,22 +404,20 @@ namespace Sashimi.Terraform.Tests
                     {
                         _.Variables.Add(TerraformSpecialVariables.Action.Terraform.AdditionalActionParams,
                             $"-state=\"{Path.Combine(stateFileFolder.DirectoryPath, "terraform.tfstate")}\" -refresh=false");
-                    }, "PlanDetailedExitCode", null,
+                    }, "PlanDetailedExitCode",
                     typeof(TerraformPlanActionHandler), typeof(TerraformApplyActionHandler),
                     typeof(TerraformPlanActionHandler)).GetEnumerator();
                 outputs.MoveNext();
-                outputs.Current.Should()
-                    .Contain(
-                        "Saving variable 'Octopus.Action[\"\"].Output.TerraformPlanDetailedExitCode' with the detailed exit code of the plan, with value '2'");
+                outputs.Current.OutputVariables.ContainsKey("TerraformPlanDetailedExitCode").Should().BeTrue();
+                outputs.Current.OutputVariables["TerraformPlanDetailedExitCode"].Value.Should().Be("2");
 
                 outputs.MoveNext();
-                outputs.Current.Should()
+                outputs.Current.FullLog.Should()
                     .Contain("apply -no-color -auto-approve");
 
                 outputs.MoveNext();
-                outputs.Current.Should()
-                    .Contain(
-                        "Saving variable 'Octopus.Action[\"\"].Output.TerraformPlanDetailedExitCode' with the detailed exit code of the plan, with value '0'");
+                outputs.Current.OutputVariables.ContainsKey("TerraformPlanDetailedExitCode").Should().BeTrue();
+                outputs.Current.OutputVariables["TerraformPlanDetailedExitCode"].Value.Should().Be("0");
             }
         }
 
@@ -428,7 +441,13 @@ namespace Sashimi.Terraform.Tests
         string ExecuteAndReturnLogOutput(Type commandType, Action<TestActionHandlerContext<Program>> populateVariables,
             string folderName, Action<TestActionHandlerResult>? assert = null)
         {
-            return ExecuteAndReturnLogOutput(populateVariables, folderName, assert, commandType).Single();
+            var assertResult = assert ?? (_ => { });
+
+            var result = ExecuteAndReturnLogOutput(populateVariables, folderName, commandType).Single();
+
+            assertResult(result);
+
+            return result.FullLog;
         }
 
         string ExecuteAndReturnLogOutput<T>(Action<TestActionHandlerContext<Program>> populateVariables,
@@ -437,15 +456,14 @@ namespace Sashimi.Terraform.Tests
             return ExecuteAndReturnLogOutput(typeof(T), populateVariables, folderName, assert);
         }
 
-        IEnumerable<string> ExecuteAndReturnLogOutput(Action<TestActionHandlerContext<Program>> populateVariables,
-            string folderName, Action<TestActionHandlerResult>? assert, params Type[] commandTypes)
+        IEnumerable<TestActionHandlerResult> ExecuteAndReturnLogOutput(Action<TestActionHandlerContext<Program>> populateVariables,
+            string folderName, params Type[] commandTypes)
         {
             var terraformFiles = TestEnvironment.GetTestPath(folderName);
-            var assertResult = assert ?? (_ => { });
             
             foreach (var commandType in commandTypes)
             {
-                var output = String.Empty;
+                TestActionHandlerResult outputResult = null!;
                 TestActionHandler<Program>(commandType, context =>
                     {
                         context.Variables.Add(KnownVariables.Action.Script.ScriptSource,
@@ -460,14 +478,11 @@ namespace Sashimi.Terraform.Tests
                     }, result =>
                     {
                         Assert.IsTrue(result.WasSuccessful);
-                        assertResult(result);
-                        output = result.FullLog;
+                        outputResult = result;
                     }
                 );
 
-                Console.WriteLine(output);
-
-                yield return output;
+                yield return outputResult;
             }
         }
     }

--- a/source/Sashimi.Terraform/ActionHandler/TerraformVariableFileGenerator.cs
+++ b/source/Sashimi.Terraform/ActionHandler/TerraformVariableFileGenerator.cs
@@ -112,10 +112,10 @@ namespace Sashimi.Terraform.ActionHandler
         {
             if (propertyType != null && propertyType.StartsWith(TerraformDataTypes.RawPrefix))
             {
-                return "\"" + HclParser.EscapeString(property.Name) + "\" = " + property.Value;
+                return HclParser.EscapeString(property.Name) + " = " + property.Value;
             }
 
-            return "\"" + HclParser.EscapeString(property.Name) + "\" = \"" + HclParser.EscapeString(property.Value.ToString()) + "\"";
+            return HclParser.EscapeString(property.Name) + " = \"" + HclParser.EscapeString(property.Value.ToString()) + "\"";
         }
 
         public static string? GetPropertyType(Metadata metadata, string property)


### PR DESCRIPTION
The additional tests are existing tests in the https://github.com/OctopusDeploy/OctopusDeploy/tree/master/source/Octopus.E2ETests.API/Scripts/Terraform

This should complete all the work for terraform, and we can delete those E2E tests from the Server.

Best way to review this PR is to review commit by commit, the 2nd commit is really the one to review, the 1st one is just a bit of refactoring to the existing tests. 