### PR TITLE
Fixed E2E tests for DeployAwsCloudFormationCommand

### DIFF
--- a/source/Calamari.Aws/DeployAwsCloudFormationCommand.cs
+++ b/source/Calamari.Aws/DeployAwsCloudFormationCommand.cs
@@ -84,7 +84,7 @@ namespace Calamari.Aws
         CloudFormationTemplate GetCloudFormationTemplate(string pathToPackage)
         {
             var templateFile = variables.Get(SpecialVariableNames.Aws.CloudFormation.Template);
-            var templateParameterFile = variables.Get(SpecialVariableNames.Aws.CloudFormation.TemplateParameters);
+            var templateParameterFile = variables.Get(SpecialVariableNames.Aws.CloudFormation.TemplateParametersRaw);
             var isFileInPackage = !string.IsNullOrWhiteSpace(pathToPackage);
 
             var templateResolver = new TemplateResolver(fileSystem);

--- a/source/Calamari.Aws/SpecialVariableNames.cs
+++ b/source/Calamari.Aws/SpecialVariableNames.cs
@@ -31,6 +31,7 @@ namespace Calamari.Aws
                 public const string StackName = "Octopus.Action.Aws.CloudFormationStackName";
                 public const string Template = "Octopus.Action.Aws.CloudFormationTemplate";
                 public const string TemplateParameters = "Octopus.Action.Aws.CloudFormationTemplateParameters";
+                public const string TemplateParametersRaw = "Octopus.Action.Aws.CloudFormationTemplateParametersRaw";
                 public const string Properties = "Octopus.Action.Aws.CloudFormationProperties";
                 public const string RoleArn = "Octopus.Action.Aws.CloudFormation.RoleArn";
 

--- a/source/Sashimi.Aws.Tests/RunScript/AwsRunScriptActionHandlerFixture.cs
+++ b/source/Sashimi.Aws.Tests/RunScript/AwsRunScriptActionHandlerFixture.cs
@@ -1,11 +1,8 @@
-﻿using System.Collections.Generic;
-using Calamari.Deployment;
-using FluentAssertions;
+﻿using FluentAssertions;
 using NSubstitute;
 using NSubstitute.Extensions;
 using NUnit.Framework;
 using Octopus.Diagnostics;
-using Octopus.Server.Extensibility.Metadata;
 using Sashimi.Aws.ActionHandler;
 using Sashimi.Server.Contracts;
 using Sashimi.Server.Contracts.ActionHandlers;

--- a/source/Sashimi.Aws.Tests/RunScript/AwsS3UploadActionHandlerFixture.cs
+++ b/source/Sashimi.Aws.Tests/RunScript/AwsS3UploadActionHandlerFixture.cs
@@ -23,7 +23,7 @@ namespace Sashimi.Aws.Tests.RunScript
         {
             var bucketName = "octopus-e2e-tests";
             var region = "ap-southeast-1";
-            var folderPrefix = $"test/{Guid.NewGuid().ToString()}/";
+            var folderPrefix = $"test/{Guid.NewGuid()}/";
             var path = TestEnvironment.GetTestPath(@"AwsS3Sample\AwsS3Sample.1.0.0.nupkg");
 
             ActionHandlerTestBuilder.Create<AwsUploadS3ActionHandler, Program>()

--- a/source/Sashimi.Aws.Tests/Sashimi.Aws.Tests.csproj
+++ b/source/Sashimi.Aws.Tests/Sashimi.Aws.Tests.csproj
@@ -38,6 +38,9 @@
         <None Update="CloudFormation\package-withparameters\template.yaml">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Update="Packages\CloudFormationS3.1.0.0.nupkg">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
 
 </Project>

--- a/source/Sashimi.Aws/ActionHandler/AwsRunCloudFormationActionHandler.cs
+++ b/source/Sashimi.Aws/ActionHandler/AwsRunCloudFormationActionHandler.cs
@@ -27,13 +27,6 @@ namespace Sashimi.Aws.ActionHandler
         {
             var builder = context.CalamariCommand(CalamariFlavour.CalamariAws, KnownAwsCalamariCommands.Commands.DeployAwsCloudFormation);
 
-            CloudFormationCalamariPresets.TemplatesAndParameters(context.Variables, builder);
-
-            // builder.WithArgument("waitForCompletion", context.Variables.GetFlag(AwsSpecialVariables.Action.Aws.WaitForCompletion, false).ToString());
-            // builder.WithArgument("stackName", context.Variables.Get(AwsSpecialVariables.Action.Aws.CloudFormation.StackName, ""));
-            // builder.WithArgument("disableRollback", context.Variables.GetFlag(AwsSpecialVariables.Action.Aws.DisableRollback, true).ToString());
-            // builder.WithArgument("extensions", CalamariExtensions.Aws);
-
             return builder.Execute();
         }
     }

--- a/source/Sashimi.Tests.Shared/Server/ActionHandlerTestBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/ActionHandlerTestBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using Autofac;
 using Calamari;
 using Calamari.Tests.Shared;
@@ -27,6 +28,7 @@ namespace Sashimi.Tests.Shared.Server
         public static void WithPackage<TCalamariProgram>(this TestActionHandlerContext<TCalamariProgram> context, string path)
             where TCalamariProgram : CalamariFlavourProgram
         {
+            context.Variables.Add(KnownVariables.OriginalPackageDirectoryPath, Path.GetDirectoryName(path));
             context.Variables.Add(KnownVariables.Action.Packages.PackageId, path);
             context.Variables.Add(KnownVariables.Action.Packages.FeedId, "FeedId");
         }

--- a/source/Server.Contracts/KnownVariables.cs
+++ b/source/Server.Contracts/KnownVariables.cs
@@ -3,6 +3,8 @@
     public static class KnownVariables
     {
         public static readonly string UseRawScript = "OctopusUseRawScript";
+        public static readonly string OriginalPackageDirectoryPath = "OctopusOriginalPackageDirectoryPath";
+
 
         public static class Project
         {


### PR DESCRIPTION
As title.

Fixed the following issue(s):

1. A missing variable `KnownVariables.OriginalPackageDirectoryPath` in the test case
2. `GetCloudFormationTemplate()` was reading from a wrong variable name for the test case
3. Package to deploy with was not copied to the test folder and the path was incorrect
4. Restructure the test case so it no longer swallows our test failure (exception)