### PR TITLE
Rmove tee and map usage

### DIFF
--- a/source/Calamari.Aws.Tests/S3/S3ObjectExtensionsFixture.cs
+++ b/source/Calamari.Aws.Tests/S3/S3ObjectExtensionsFixture.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Amazon.S3.Model;
 using Calamari.Aws.Integration.S3;
 using NUnit.Framework;
-using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Aws.Tests.S3
 {
@@ -16,15 +15,11 @@ namespace Calamari.Aws.Tests.S3
         {
             var useHeaderValues = GetKnownSpecialKeyApplier();
 
-            PutObjectRequest request = new PutObjectRequest().Tee(r =>
-            {
-                useHeaderValues(r.Headers);
-            });
+            var request = new PutObjectRequest();
+            useHeaderValues(request.Headers);
 
-            GetObjectMetadataResponse response = new GetObjectMetadataResponse().Tee(r =>
-            {
-                useHeaderValues(r.Headers);
-            });
+            var response = new GetObjectMetadataResponse();
+            useHeaderValues(response.Headers);
 
             var result = S3ObjectExtensions.MetadataEq(request.ToCombinedMetadata(), response.ToCombinedMetadata());
             Assert.IsTrue(result, "Metadata was found to be not equal, but should match.");
@@ -36,15 +31,11 @@ namespace Calamari.Aws.Tests.S3
             var useHeaderValues = GetKnownSpecialKeyApplier();
             var useDifferentHeaderValues = GetKnownSpecialKeyApplier();
 
-            PutObjectRequest request = new PutObjectRequest().Tee(r =>
-            {
-                useHeaderValues(r.Headers);
-            });
+            var request = new PutObjectRequest();
+            useHeaderValues(request.Headers);
 
-            GetObjectMetadataResponse response = new GetObjectMetadataResponse().Tee(r =>
-            {
-                useDifferentHeaderValues(r.Headers);
-            });
+            var response = new GetObjectMetadataResponse();
+            useDifferentHeaderValues(response.Headers);
 
             var result = S3ObjectExtensions.MetadataEq(request.ToCombinedMetadata(), response.ToCombinedMetadata());
             Assert.IsFalse(result, "The comparison was found to be equal, however the special headers differ.");
@@ -56,17 +47,13 @@ namespace Calamari.Aws.Tests.S3
         {
             var useHeaderValues = GetKnownSpecialKeyApplier();
 
-            PutObjectRequest request = new PutObjectRequest().Tee(r =>
-            {
-                useHeaderValues(r.Headers);
-                r.Metadata.Add("Cowabunga", "Baby");
-            });
+            var request = new PutObjectRequest();
+            useHeaderValues(request.Headers);
+            request.Metadata.Add("Cowabunga", "Baby");
 
-            GetObjectMetadataResponse response = new GetObjectMetadataResponse().Tee(r =>
-            {
-                useHeaderValues(r.Headers);
-                r.Metadata.Add("Cowabunga", "Baby2");
-            });
+            var response = new GetObjectMetadataResponse();
+            useHeaderValues(response.Headers);
+            response.Metadata.Add("Cowabunga", "Baby2");
             
             var result = S3ObjectExtensions.MetadataEq(request.ToCombinedMetadata(), response.ToCombinedMetadata());
             Assert.IsFalse(result, "Metadata comparison was found to be match, but should differ");
@@ -77,17 +64,13 @@ namespace Calamari.Aws.Tests.S3
         {
             var useHeaderValues = GetKnownSpecialKeyApplier();
 
-            PutObjectRequest request = new PutObjectRequest().Tee(r =>
-            {
-                useHeaderValues(r.Headers);
-                r.Metadata.Add("Meep Meep", "Baby2");
-            });
+            var request = new PutObjectRequest();
+            useHeaderValues(request.Headers);
+            request.Metadata.Add("Meep Meep", "Baby2");
 
-            GetObjectMetadataResponse response = new GetObjectMetadataResponse().Tee(r =>
-            {
-                useHeaderValues(r.Headers);
-                r.Metadata.Add("Cowabunga", "Baby2");
-            });
+            var response = new GetObjectMetadataResponse();
+            useHeaderValues(response.Headers);
+            response.Metadata.Add("Cowabunga", "Baby2");
 
             var result = S3ObjectExtensions.MetadataEq(request.ToCombinedMetadata(), response.ToCombinedMetadata());
             Assert.IsFalse(result, "Metadata comparison was found to be match, but should differ");
@@ -96,19 +79,17 @@ namespace Calamari.Aws.Tests.S3
         [Test]
         public void MetadataComparisonIgnoresUnknownSpecialHeaders()
         {
-            PutObjectRequest request = new PutObjectRequest().Tee(r =>
+            var request = new PutObjectRequest
             {
-                r.Headers["Geppetto"] = "Pinocchio ";
+                Headers = {["Geppetto"] = "Pinocchio "}
+            };
+            request.Metadata.Add("Cowabunga", "Baby");
 
-                r.Metadata.Add("Cowabunga", "Baby");
-            });
-
-            GetObjectMetadataResponse response = new GetObjectMetadataResponse().Tee(r =>
+            var response = new GetObjectMetadataResponse
             {
-                r.Headers["Crazy"] = "Town";
-
-                r.Metadata.Add("Cowabunga", "Baby");
-            });
+                Headers = { ["Crazy"] = "Town " }
+            };
+            response.Metadata.Add("Cowabunga", "Baby");
 
             var result = S3ObjectExtensions.MetadataEq(request.ToCombinedMetadata(), response.ToCombinedMetadata());
             Assert.IsTrue(result, "Metadata was found to be equal, but should differ");

--- a/source/Calamari.Aws.Tests/S3Fixture.cs
+++ b/source/Calamari.Aws.Tests/S3Fixture.cs
@@ -22,7 +22,6 @@ using FluentAssertions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using NUnit.Framework;
-using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Aws.Tests
 {
@@ -31,14 +30,14 @@ namespace Calamari.Aws.Tests
     {
         private const string BucketName = "octopus-e2e-tests";
 
-        private static JsonSerializerSettings GetEnrichedSerializerSettings()
+        static JsonSerializerSettings GetEnrichedSerializerSettings()
         {
-            return JsonSerialization.GetDefaultSerializerSettings()
-                .Tee(x =>
-                {
-                    x.Converters.Add(new FileSelectionsConverter());
-                    x.ContractResolver = new CamelCasePropertyNamesContractResolver();
-                });
+            var settings = JsonSerialization.GetDefaultSerializerSettings();
+
+            settings.Converters.Add(new FileSelectionsConverter());
+            settings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+
+            return settings;
         }
 
         [Test]

--- a/source/Calamari.Aws/Deployment/CloudFormation/CloudFormationService.cs
+++ b/source/Calamari.Aws/Deployment/CloudFormation/CloudFormationService.cs
@@ -10,7 +10,6 @@ using Calamari.Aws.Integration.CloudFormation;
 using Calamari.Aws.Integration.CloudFormation.Templates;
 using Calamari.Aws.Util;
 using Octopus.CoreUtilities;
-using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Aws.Deployment.CloudFormation
 {
@@ -111,8 +110,9 @@ namespace Calamari.Aws.Deployment.CloudFormation
             List<VariableOutput> ConvertStackOutputs(Stack stack) =>
                 stack.Outputs.Select(p => new VariableOutput(p.OutputKey, p.OutputValue)).ToList();
 
-            return (await query()).Select(ConvertStackOutputs)
-                .Map(result => (result: result.SomeOr(new List<VariableOutput>()), success: true));
+            var result = await query();
+
+            return (result: result.Select(ConvertStackOutputs).SomeOr(new List<VariableOutput>()), success: true);
         }
 
         async Task<IReadOnlyCollection<VariableOutput>> GetOutputVariablesWithRetry(Func<Task<Maybe<Stack>>> query)
@@ -211,8 +211,9 @@ namespace Calamari.Aws.Deployment.CloudFormation
             {
                 var client = await amazonCloudFormationClient.Value;
 
-                return (await client.CreateChangeSetAsync(request))
-                    .Map(x => new RunningChangeSet(new StackArn(x.StackId), new ChangeSetArn(x.Id)));
+                var response = await client.CreateChangeSetAsync(request);
+
+                return new RunningChangeSet(new StackArn(response.StackId), new ChangeSetArn(response.Id));
             }
             catch (AmazonCloudFormationException ex) when (ex.ErrorCode == "AccessDenied")
             {
@@ -272,11 +273,18 @@ namespace Calamari.Aws.Deployment.CloudFormation
         /// <param name="cloudFormationTemplate"></param>
         async Task<string> DeployStack(CloudFormationTemplate cloudFormationTemplate, StackArn stackArn, string roleArn, IReadOnlyCollection<string> iamCapabilities, bool isRollbackDisabled, bool waitForCompletion)
         {
-            var stackId = await cloudFormationTemplate.Inputs
-                // Use the parameters to either create or update the stackArn
-                .Map(async parameters => await StackExists(stackArn, StackStatus.DoesNotExist) != StackStatus.DoesNotExist
-                    ? await UpdateCloudFormation(cloudFormationTemplate, stackArn, roleArn, iamCapabilities, isRollbackDisabled)
-                    : await CreateCloudFormation(cloudFormationTemplate, stackArn, roleArn, iamCapabilities, isRollbackDisabled));
+            var stackStatus = await StackExists(stackArn, StackStatus.DoesNotExist);
+
+            string stackId;
+
+            if (stackStatus != StackStatus.DoesNotExist)
+            {
+                stackId = await UpdateCloudFormation(cloudFormationTemplate, stackArn, roleArn, iamCapabilities, isRollbackDisabled);
+            }
+            else
+            {
+                stackId = await CreateCloudFormation(cloudFormationTemplate, stackArn, roleArn, iamCapabilities, isRollbackDisabled);
+            }
 
             if (waitForCompletion)
             {
@@ -485,8 +493,7 @@ namespace Calamari.Aws.Deployment.CloudFormation
         /// <param name="exception">The exception</param>
         protected void LogAmazonServiceException(AmazonServiceException exception)
         {
-            exception.GetWebExceptionMessage()
-                .Tee(message => stackEventLogger.Warn("AWS-CLOUDFORMATION-ERROR-0014", message));
+            stackEventLogger.Warn("AWS-CLOUDFORMATION-ERROR-0014", exception.GetWebExceptionMessage());
         }
 
         /// <summary>

--- a/source/Calamari.Aws/Integration/CloudFormation/Templates/CloudFormationTemplate.cs
+++ b/source/Calamari.Aws/Integration/CloudFormation/Templates/CloudFormationTemplate.cs
@@ -5,7 +5,6 @@ using Amazon.CloudFormation.Model;
 using Calamari.Common.Util;
 using Calamari.Integration.FileSystem;
 using Newtonsoft.Json;
-using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Aws.Integration.CloudFormation.Templates
 {
@@ -32,7 +31,7 @@ namespace Calamari.Aws.Integration.CloudFormation.Templates
         public string Content => content();
 
         public IEnumerable<Parameter> Inputs => parameters.Inputs;
-        public bool HasOutputs => Content.Map(OutputsRe.IsMatch);
+        public bool HasOutputs => OutputsRe.IsMatch(Content);
         public IEnumerable<StackFormationNamedOutput> Outputs  => HasOutputs ? parse(Content) : new List<StackFormationNamedOutput>();
     }
 }

--- a/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
+++ b/source/Calamari.Aws/Integration/S3/S3ObjectExtensions.cs
@@ -6,7 +6,6 @@ using System.Security.Cryptography;
 using Calamari.Integration.FileSystem;
 using Calamari.Util;
 using Octopus.CoreUtilities;
-using Octopus.CoreUtilities.Extensions;
 using Tag = Amazon.S3.Model.Tag;
 
 namespace Calamari.Aws.Integration.S3
@@ -97,21 +96,23 @@ namespace Calamari.Aws.Integration.S3
 
         public static PutObjectRequest WithMetadata(this PutObjectRequest request, IEnumerable<KeyValuePair<string, string>> source)
         {
-            return request.Tee(x =>
+            Guard.NotNull(request, $"'{nameof(request)}' cannot be null.");
+            Guard.NotNull(source, $"'{nameof(source)}' cannot be null.");
+
+            foreach (var item in source)
             {
-                foreach (var item in source)
+                var key = item.Key.Trim();
+                if (!SupportedSpecialHeaders.ContainsKey(key))
                 {
-                    var key = item.Key.Trim();
-                    if (!SupportedSpecialHeaders.ContainsKey(key))
-                    {
-                        x.Metadata.Add(key, item.Value?.Trim());
-                    }
-                    else
-                    {
-                        x.Headers[key] = item.Value?.Trim();
-                    }
+                    request.Metadata.Add(key, item.Value?.Trim());
                 }
-            });
+                else
+                {
+                    request.Headers[key] = item.Value?.Trim();
+                }
+            }
+
+            return request;
         }
 
         public static PutObjectRequest WithMetadata(this PutObjectRequest request, IHaveMetadata source)
@@ -121,7 +122,12 @@ namespace Calamari.Aws.Integration.S3
 
         public static PutObjectRequest WithTags(this PutObjectRequest request, IHaveTags source)
         {
-            return request.Tee(x => x.TagSet = source.Tags.ToTagSet());
+            Guard.NotNull(request, $"'{nameof(request)}' cannot be null.");
+            Guard.NotNull(source, $"'{nameof(source)}' cannot be null.");
+
+            request.TagSet = source.Tags?.ToTagSet() ?? new List<Tag>();
+
+            return request;
         }
 
         static Maybe<byte[]> GetMd5Checksum(ICalamariFileSystem fileSystem, string path)
@@ -143,7 +149,7 @@ namespace Calamari.Aws.Integration.S3
 
         public static string Md5DigestToHexString(this PutObjectRequest request)
         {
-            return Convert.FromBase64String(request.MD5Digest).Map(BinaryExtensions.ToHexString);
+            return Convert.FromBase64String(request.MD5Digest).ToHexString();
         }
 
         public static ETag GetEtag(this GetObjectMetadataResponse metadata)

--- a/source/Calamari.Aws/Integration/S3/VariableS3TargetOptionsProvider.cs
+++ b/source/Calamari.Aws/Integration/S3/VariableS3TargetOptionsProvider.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Calamari.Aws.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Aws.Integration.S3
 {
@@ -19,24 +18,26 @@ namespace Calamari.Aws.Integration.S3
 
         IEnumerable<S3FileSelectionProperties> GetFileSelections()
         {
-            return variables.Get(SpecialVariableNames.Aws.S3.FileSelections)
-                ?.Map(Deserialize<List<S3FileSelectionProperties>>);
+            var fileSelectionsAsJson = variables.Get(SpecialVariableNames.Aws.S3.FileSelections);
+
+            return fileSelectionsAsJson == null ? null : Deserialize<List<S3FileSelectionProperties>>(fileSelectionsAsJson);
         }
 
         S3PackageOptions GetPackageOptions()
         {
-            return variables.Get(SpecialVariableNames.Aws.S3.PackageOptions)
-                ?.Map(Deserialize<S3PackageOptions>);
+            var packageOptionsAsJson = variables.Get(SpecialVariableNames.Aws.S3.PackageOptions);
+
+            return packageOptionsAsJson == null ? null : Deserialize<S3PackageOptions>(packageOptionsAsJson);
         }
 
         static JsonSerializerSettings GetEnrichedSerializerSettings()
         {
-            return JsonSerialization.GetDefaultSerializerSettings()
-                .Tee(x =>
-                {
-                    x.Converters.Add(new FileSelectionsConverter());
-                    x.ContractResolver = new CamelCasePropertyNamesContractResolver();
-                });
+            var settings = JsonSerialization.GetDefaultSerializerSettings();
+
+            settings.Converters.Add(new FileSelectionsConverter());
+            settings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+
+            return settings;
         }
 
         static T Deserialize<T>(string value)

--- a/source/Calamari.Terraform/TerraformCliExecutor.cs
+++ b/source/Calamari.Terraform/TerraformCliExecutor.cs
@@ -8,11 +8,10 @@ using Calamari.Extensions;
 using Calamari.Integration.FileSystem;
 using Calamari.Integration.Processes;
 using Calamari.Integration.Proxies;
-using Octopus.CoreUtilities.Extensions;
 
 namespace Calamari.Terraform
 {
-    class TerraformCliExecutor : IDisposable
+    internal class TerraformCliExecutor : IDisposable
     {
         readonly ILog log;
         readonly ICalamariFileSystem fileSystem;
@@ -191,13 +190,22 @@ namespace Calamari.Terraform
         /// <summary>
         /// Create a list of -var-file arguments from the newline separated list of variable files 
         /// </summary>
-        public string TerraformVariableFiles =>
-            deployment.Variables
-                .Get(TerraformSpecialVariables.Action.Terraform.VarFiles)
-                ?.Map(var => Regex.Split(var, "\r?\n"))
-                .Select(var => $"-var-file=\"{var}\"")
-                .ToList()
-                .Map(list => string.Join(" ", list));
+        public string TerraformVariableFiles 
+        {
+            get
+            {
+                var varFilesAsString = deployment.Variables.Get(TerraformSpecialVariables.Action.Terraform.VarFiles);
+
+                if (varFilesAsString == null) return null;
+
+                var varFiles = Regex.Split(varFilesAsString, "\r?\n")
+                    .Select(var => $"-var-file=\"{var}\"")
+                    .ToList();
+
+                return string.Join(" ", varFiles);
+            } 
+        }
+            
 
         void InitializeTerraformEnvironmentVariables()
         {

--- a/source/Sashimi.Terraform/CloudTemplates/TerraformJsonCloudTemplateHandler.cs
+++ b/source/Sashimi.Terraform/CloudTemplates/TerraformJsonCloudTemplateHandler.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
-using Octopus.CoreUtilities.Extensions;
 using Octopus.Server.Extensibility.Metadata;
 using Sashimi.Server.Contracts;
 using Sashimi.Server.Contracts.CloudTemplates;
@@ -25,29 +24,32 @@ namespace Sashimi.Terraform.CloudTemplates
 
         public Metadata ParseTypes(string template)
         {
-            return template?
-                .Map(GetVariables)
-                .Map(variable => variable.Select(p => new PropertyMetadata
-                    {
-                        DisplayInfo = new DisplayInfo
-                        {
-                            Description = p.Value.SelectToken("description")?.ToString(),
-                            Label = p.Key,
-                            Required = true,
-                        },
-                        Type = GetType(p.Value),
-                        Name = p.Key,
-                    }).ToList()
-                )
-                .Map(properties => new List<TypeMetadata>
+            if (template == null) return new Metadata();
+
+            var jTokenDict = GetVariables(template);
+            var properties = jTokenDict.Select(p => new PropertyMetadata
+            {
+                DisplayInfo = new DisplayInfo
+                {
+                    Description = p.Value.SelectToken("description")?.ToString(),
+                    Label = p.Key,
+                    Required = true,
+                },
+                Type = GetType(p.Value),
+                Name = p.Key,
+            }).ToList();
+
+            return new Metadata
+            {
+                Types = new List<TypeMetadata>
                 {
                     new TypeMetadata
                     {
                         Name = TerraformDataTypes.TerraformTemplateTypeName,
                         Properties = properties
                     }
-                })
-                .Map(typeMetadata => new Metadata() {Types = typeMetadata}) ?? new Metadata();
+                }
+            };
         }
 
         public object ParseModel(string template)
@@ -58,7 +60,7 @@ namespace Sashimi.Terraform.CloudTemplates
                 .ToDictionary(x => x.Key, x => x.Value) ?? new Dictionary<string, object?>();
         }
 
-        object? GetDefaultValue(JToken argValue)
+        static object? GetDefaultValue(JToken argValue)
         {
             var defaultValueToken = argValue.SelectToken("default");
             return defaultValueToken?.ToString();


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? -->

This PR is to remove any usage of `Tee` and `Map` function in `Sashimi`

# Results

<!-- Describe the result of the change including a link to any resolved issues. -->

No longer relying on either Tee or Map.


<!-- Consider adding a before/after log excerpt or screen capture. -->

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
Correctness ✔️ 
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites
- [x] I have considered informing or consulting the right people, e.g.: 
  - For changes to the execution pipeline: [`#topic-execution`](https://octopusdeploy.slack.com/archives/C3KT1DFSM)
  - For other changes, consider the other `#topic-...` channels
- [x] I have considered whether this should be a patch or wait for a minor.
- [x] I have considered appropriate testing for my change.
    <!-- Describe what has been covered: Automated testing/ Exploratory testing/ Nothing required? 
         Is the build green? -->
