### PR TITLE
Make VariableType a TinyType instead and use a VariableTypeRegistry on the server side to expose richer properties

### DIFF
--- a/source/Server.Contracts/Actions/Templates/ControlType.cs
+++ b/source/Server.Contracts/Actions/Templates/ControlType.cs
@@ -1,54 +1,26 @@
 using System.Collections.Generic;
+using Octopus.TinyTypes;
 using Sashimi.Server.Contracts.Variables;
 
 namespace Sashimi.Server.Contracts.Actions.Templates
 {
-    public class ControlType
+    public class ControlType : CaseInsensitiveTypedString
     {
         public static readonly ControlType SingleLineText = new ControlType("SingleLineText");
         public static readonly ControlType MultiLineText = new ControlType("MultiLineText");
         public static readonly ControlType Select = new ControlType("Select");
         public static readonly ControlType Checkbox = new ControlType("Checkbox");
-        public static readonly ControlType Sensitive = new ControlType("Sensitive", VariableType.Sensitive);
+        public static readonly ControlType Sensitive = new ControlType("Sensitive");
         public static readonly ControlType StepName = new ControlType("StepName");
-        public static readonly ControlType AzureAccount = new ControlType("AzureAccount", VariableType.AzureAccount);
-        public static readonly ControlType Certificate = new ControlType("Certificate", VariableType.Certificate);
-        public static readonly ControlType WorkerPool = new ControlType("WorkerPool", VariableType.WorkerPool);
-        public static readonly ControlType AmazonWebServicesAccount = new ControlType("AmazonWebServicesAccount", VariableType.AmazonWebServicesAccount);
+        public static readonly ControlType Certificate = new ControlType("Certificate");
+        public static readonly ControlType WorkerPool = new ControlType("WorkerPool");
 
-        public ControlType(string name)
-            :this (name, VariableType.String)
+        //TODO: Move out to respective projects
+        public static readonly ControlType AmazonWebServicesAccount = new ControlType("AmazonWebServicesAccount");
+        public static readonly ControlType AzureAccount = new ControlType("AzureAccount");
+
+        public ControlType(string value) : base(value)
         {
         }
-
-        public ControlType(string name, VariableType variableType)
-        {
-            Name = name;
-            VariableType = variableType;
-        }
-
-        public string Name { get; set; }
-        public VariableType VariableType { get; set; }
-        protected bool Equals(ControlType other)
-        {
-            return Name == other.Name;
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((ControlType) obj);
-        }
-
-        public override int GetHashCode() 
-            => (Name != null ? Name.GetHashCode() : 0);
-
-        public static bool operator ==(ControlType left, ControlType right) 
-            => Equals(left, right);
-
-        public static bool operator !=(ControlType left, ControlType right) 
-            => !Equals(left, right);
     }
 }

--- a/source/Server.Contracts/Sashimi.Server.Contracts.csproj
+++ b/source/Server.Contracts/Sashimi.Server.Contracts.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Octopus.Data" Version="5.0.0" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
     <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.0" />
+    <PackageReference Include="Octopus.TinyTypes" Version="0.1.3" />
   </ItemGroup>
 
 </Project>

--- a/source/Server.Contracts/Variables/VariableType.cs
+++ b/source/Server.Contracts/Variables/VariableType.cs
@@ -1,45 +1,21 @@
-﻿﻿using System;
+﻿using System;
+using Octopus.TinyTypes;
 
 namespace Sashimi.Server.Contracts.Variables
 {
-    public class VariableType
+    public class VariableType : CaseInsensitiveTypedString
     {
-        public static readonly VariableType String = new VariableType("String");
-        public static readonly VariableType Sensitive = new VariableType("Sensitive");
-        public static readonly VariableType Certificate = new VariableType("Certificate", Contracts.DocumentType.Certificate);
-        public static readonly VariableType WorkerPool = new VariableType("WorkerPool", Contracts.DocumentType.WorkerPool);
-        public static readonly VariableType AmazonWebServicesAccount = new VariableType("AmazonWebServicesAccount", Contracts.DocumentType.Account);
-        public static readonly VariableType AzureAccount = new VariableType("AzureAccount", Contracts.DocumentType.Account);
+        public static VariableType String => new VariableType("String");
+        public static VariableType Sensitive => new VariableType("Sensitive");
+        public static VariableType Certificate => new VariableType("Certificate");
+        public static VariableType WorkerPool => new VariableType("WorkerPool");
 
-        public VariableType(string name, DocumentType? documentType = null)
+        //TODO: Move out to respective projects
+        public static VariableType AmazonWebServicesAccount => new VariableType("AmazonWebServicesAccount");
+        public static VariableType AzureAccount => new VariableType("AzureAccount");
+
+        public VariableType(string value) : base(value)
         {
-            Name = name;
-            DocumentType = documentType;
         }
-
-        public string Name { get; }
-        public DocumentType? DocumentType { get; }
-
-        protected bool Equals(VariableType other)
-        {
-            return Name == other.Name;
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((VariableType) obj);
-        }
-
-        public override int GetHashCode() 
-            => (Name != null ? Name.GetHashCode() : 0);
-
-        public static bool operator ==(VariableType left, VariableType right) 
-            => Equals(left, right);
-
-        public static bool operator !=(VariableType left, VariableType right) 
-            => !Equals(left, right);
     }
 }


### PR DESCRIPTION
Making `VariableType` simple so `VariableDeclaration` can reference this and not worry about resolving the type from the registry on deserialization.