### PR TITLE
Ensure aws resources is destroyed after test

### DIFF
--- a/source/Sashimi.Terraform.Tests/AWS/example.tf
+++ b/source/Sashimi.Terraform.Tests/AWS/example.tf
@@ -10,6 +10,7 @@ variable "bucket_name" {
 
 resource "aws_s3_bucket" "mybucket" {
   bucket = "${var.bucket_name}"
+  force_destroy = true
   acl    = "private"
   tags = {
       Name        = "My bucket"

--- a/source/Server.Contracts/KnownVariables.cs
+++ b/source/Server.Contracts/KnownVariables.cs
@@ -3,7 +3,8 @@
     public static class KnownVariables
     {
         public static readonly string UseRawScript = "OctopusUseRawScript";
-        
+        public static readonly string OriginalPackageDirectoryPath = "OctopusOriginalPackageDirectoryPath";
+
         public static class Project
         {
              public static readonly string Id = "Octopus.Project.Id";


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? -->

The `AwsIntegration` test case under `Sashimi.Terraform.Tests` is not deleting the `aws` resource it provisions after test run.

Actual problem: 
`Terraform` uses a state file to keep track of what happened before in the working directory.
However, the working directory in our test case is switched between different `ActionHandler` execution, so there is no `Terraform` state file in the working directory when we execute `TerraformDestroyActionHandler`. In other words, `Terraform` doesn't know that the resource has already been provisioned.

# Results

<!-- Describe the result of the change including a link to any resolved issues. -->

## Before:
![image](https://user-images.githubusercontent.com/12688884/82968787-71a8d680-a011-11ea-9808-4159bd36cf2a.png)

## After:
![image](https://user-images.githubusercontent.com/12688884/82966829-1e358900-a00f-11ea-9b92-8ac0200a8aa7.png)

Successful deletion.

<!-- Consider adding a before/after log excerpt or screen capture. -->

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
Correctness ✔️ 
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites
- [x] I have considered informing or consulting the right people, e.g.: 
  - For changes to the execution pipeline: [`#topic-execution`](https://octopusdeploy.slack.com/archives/C3KT1DFSM)
  - For other changes, consider the other `#topic-...` channels
- [x] I have considered whether this should be a patch or wait for a minor.
- [x] I have considered appropriate testing for my change.
    <!-- Describe what has been covered: Automated testing/ Exploratory testing/ Nothing required? 
         Is the build green? -->