### PR TITLE
Add test assertion to ensure CalamariFlavour matches what we expect

### DIFF
--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -142,6 +142,8 @@ namespace Sashimi.Tests.Shared.Server
 
             IActionHandlerResult ExecuteActionHandler(List<string> args)
             {
+                AssertMatchingCalamariFlavour();
+
                 var inMemoryLog = new InMemoryLog();
                 var constructor = typeof(TCalamariProgram).GetConstructor(
                     BindingFlags.Public | BindingFlags.Instance,
@@ -217,6 +219,13 @@ namespace Sashimi.Tests.Shared.Server
                 {
                     Environment.CurrentDirectory = originalWorkingDirectory;
                 }
+            }
+
+            void AssertMatchingCalamariFlavour()
+            {
+                var assemblyName = typeof(TCalamariProgram).Assembly.GetName();
+                if (CalamariFlavour?.Id != assemblyName.Name)
+                    throw new Exception($"The specified CalamariFlavour '{CalamariFlavour?.Id}' doesn't match that of the program exe '{assemblyName.Name}'");
             }
         }
 

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -98,6 +98,28 @@ namespace Sashimi.Tests.Shared.Server
 
         public IActionHandlerResult Execute()
         {
+            using (var working = TemporaryDirectory.Create())
+            {
+                var workingPath = working.DirectoryPath;
+
+                //HACK: set the working directory, we will need to modify Calamari to not depend on this
+                var originalWorkingDirectory = Environment.CurrentDirectory;
+                try
+                {
+                    Environment.CurrentDirectory = workingPath;
+
+                    var args = GetArgs(workingPath);
+
+                    CopyFilesToWorkingFolder(workingPath);
+
+                    return ExecuteActionHandler(args);
+                }
+                finally
+                {
+                    Environment.CurrentDirectory = originalWorkingDirectory;
+                }
+            }
+
             List<string> GetArgs(string workingPath)
             {
                 var args = new List<string> {CalamariCommand!};
@@ -196,28 +218,6 @@ namespace Sashimi.Tests.Shared.Server
                 foreach (var newPath in Directory.EnumerateFiles(sourcePath, "*.*", SearchOption.AllDirectories))
                 {
                     File.Copy(newPath, newPath.Replace(sourcePath, destinationPath), true);
-                }
-            }
-
-            using (var working = TemporaryDirectory.Create())
-            {
-                var workingPath = working.DirectoryPath;
-
-                //HACK: set the working directory, we will need to modify Calamari to not depend on this
-                var originalWorkingDirectory = Environment.CurrentDirectory;
-                try
-                {
-                    Environment.CurrentDirectory = workingPath;
-
-                    var args = GetArgs(workingPath);
-
-                    CopyFilesToWorkingFolder(workingPath);
-
-                    return ExecuteActionHandler(args);
-                }
-                finally
-                {
-                    Environment.CurrentDirectory = originalWorkingDirectory;
                 }
             }
 


### PR DESCRIPTION
Since we're running in-proc, `CalamariFlavour` doesn't actually get used, so we need to add a test assertion here. If this doesn't give us enough assurance, then we will need to consider adding a flag to run tests out of proc.

Review commit by commit