### PR TITLE
Bump Octopus.TinyTypes and Octopus.Server.Extensibility versions

### DIFF
--- a/source/Sashimi.Azure/Sashimi.Azure.csproj
+++ b/source/Sashimi.Azure/Sashimi.Azure.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.28.1" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.7-enh-use-octopus-0003" />
   </ItemGroup>
 
 </Project>

--- a/source/Sashimi.Azure/Sashimi.Azure.csproj
+++ b/source/Sashimi.Azure/Sashimi.Azure.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.28.1" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.7-enh-use-octopus-0003" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.8" />
   </ItemGroup>
 
 </Project>

--- a/source/Server.Contracts/Accounts/AccountType.cs
+++ b/source/Server.Contracts/Accounts/AccountType.cs
@@ -2,7 +2,7 @@ using Octopus.TinyTypes;
 
 namespace Sashimi.Server.Contracts.Accounts
 {
-    public class AccountType : CaseInsensitiveTypedString
+    public class AccountType : CaseInsensitiveStringTinyType
     {
         public static readonly AccountType None = new AccountType(nameof (None));
 

--- a/source/Server.Contracts/Actions/Templates/ControlType.cs
+++ b/source/Server.Contracts/Actions/Templates/ControlType.cs
@@ -3,7 +3,7 @@ using Octopus.TinyTypes;
 
 namespace Sashimi.Server.Contracts.Actions.Templates
 {
-    public class ControlType : CaseInsensitiveTypedString
+    public class ControlType : CaseInsensitiveStringTinyType
     {
         public static readonly ControlType SingleLineText = new ControlType("SingleLineText");
         public static readonly ControlType MultiLineText = new ControlType("MultiLineText");

--- a/source/Server.Contracts/Sashimi.Server.Contracts.csproj
+++ b/source/Server.Contracts/Sashimi.Server.Contracts.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Octopus.Data" Version="5.0.3" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
     <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.0" />
-    <PackageReference Include="Octopus.TinyTypes" Version="0.1.4-enh-consolidate-0004" />
+    <PackageReference Include="Octopus.TinyTypes" Version="0.1.5" />
     <PackageReference Include="Octostache" Version="2.7.0" />
   </ItemGroup>
 

--- a/source/Server.Contracts/Sashimi.Server.Contracts.csproj
+++ b/source/Server.Contracts/Sashimi.Server.Contracts.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="FluentValidation" Version="8.6.2" />
     <PackageReference Include="Octopus.Data" Version="5.0.3" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.7-enh-use-octopus-0003" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.8" />
     <PackageReference Include="Octopus.TinyTypes" Version="0.1.5" />
     <PackageReference Include="Octostache" Version="2.7.0" />
   </ItemGroup>

--- a/source/Server.Contracts/Sashimi.Server.Contracts.csproj
+++ b/source/Server.Contracts/Sashimi.Server.Contracts.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="FluentValidation" Version="8.6.2" />
     <PackageReference Include="Octopus.Data" Version="5.0.3" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.7-enh-use-octopus-0003" />
     <PackageReference Include="Octopus.TinyTypes" Version="0.1.5" />
     <PackageReference Include="Octostache" Version="2.7.0" />
   </ItemGroup>

--- a/source/Server.Contracts/Sashimi.Server.Contracts.csproj
+++ b/source/Server.Contracts/Sashimi.Server.Contracts.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Octopus.Data" Version="5.0.3" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
     <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.0" />
-    <PackageReference Include="Octopus.TinyTypes" Version="0.1.3" />
+    <PackageReference Include="Octopus.TinyTypes" Version="0.1.4-enh-consolidate-0004" />
     <PackageReference Include="Octostache" Version="2.7.0" />
   </ItemGroup>
 

--- a/source/Server.Contracts/Variables/VariableType.cs
+++ b/source/Server.Contracts/Variables/VariableType.cs
@@ -3,7 +3,7 @@ using Octopus.TinyTypes;
 
 namespace Sashimi.Server.Contracts.Variables
 {
-    public class VariableType : CaseInsensitiveTypedString
+    public class VariableType : CaseInsensitiveStringTinyType
     {
         public static readonly VariableType String = new VariableType("String");
         public static readonly VariableType Sensitive = new VariableType("Sensitive");


### PR DESCRIPTION
The `TinyType<T>` implementation in `Octopus.Server.Extensibility` has been amalgamated into the `Octopus.TinyTypes` package.

This PR pulls in the latest version of `Octopus.TinyTypes` and `Octopus.Server.Extensibility` so that our dependency versions are consistent and we don't have type collisions.

Pre-release versions of the packages generated by this PR have already been incorporated into the `OctopusDeploy` build. Tests are passing with minimal tweaks so it appears that all is fairly solid.