### PR TITLE
SensitiveStrings can actually be null objects

### DIFF
--- a/source/Calamari.Tests.Shared/LogParser/ServiceMessageParser.cs
+++ b/source/Calamari.Tests.Shared/LogParser/ServiceMessageParser.cs
@@ -101,7 +101,7 @@ namespace Calamari.Tests.Shared.LogParser
                 var element = XElement.Parse("<" + message + "/>");
                 var name = element.Name.LocalName;
                 var values = element.Attributes().ToDictionary(s => s.Name.LocalName, s => Encoding.UTF8.GetString(Convert.FromBase64String(s.Value)), StringComparer.OrdinalIgnoreCase);
-                serviceMessage(new ServiceMessage(name, values!));
+                serviceMessage(new ServiceMessage(name, values));
             }
             catch
             {

--- a/source/Sashimi.Aws.Accounts/AmazonWebServicesAccountDetails.cs
+++ b/source/Sashimi.Aws.Accounts/AmazonWebServicesAccountDetails.cs
@@ -24,8 +24,8 @@ namespace Sashimi.Aws.Accounts
             if (variable.Type != ExpandsVariableType)
                 throw new InvalidOperationException($"Can only expand variables for type {ExpandsVariableType}");
 
-            yield return new Variable($"{variable.Name}.AccessKey", AccessKey!);
-            yield return new Variable($"{variable.Name}.SecretKey", SecretKey!);
+            yield return new Variable($"{variable.Name}.AccessKey", AccessKey);
+            yield return new Variable($"{variable.Name}.SecretKey", SecretKey);
         }
 
         public override IEnumerable<Variable> ContributeVariables()

--- a/source/Sashimi.Azure.Accounts/AzureServicePrincipalAccountDetails.cs
+++ b/source/Sashimi.Azure.Accounts/AzureServicePrincipalAccountDetails.cs
@@ -42,9 +42,9 @@ namespace Sashimi.Azure.Accounts
 
         public override IEnumerable<Variable> ContributeVariables()
         {
-            yield return new Variable(SpecialVariables.Action.Azure.SubscriptionId, SubscriptionNumber!);
-            yield return new Variable(SpecialVariables.Action.Azure.ClientId, ClientId!);
-            yield return new Variable(SpecialVariables.Action.Azure.TenantId, TenantId!);
+            yield return new Variable(SpecialVariables.Action.Azure.SubscriptionId, SubscriptionNumber);
+            yield return new Variable(SpecialVariables.Action.Azure.ClientId, ClientId);
+            yield return new Variable(SpecialVariables.Action.Azure.TenantId, TenantId);
             yield return new Variable(SpecialVariables.Action.Azure.Password, Password!.Value, VariableType.Sensitive);
 
             if (!String.IsNullOrWhiteSpace(AzureEnvironment))
@@ -70,13 +70,13 @@ namespace Sashimi.Azure.Accounts
                 throw new InvalidOperationException($"Can only expand variables for type {ExpandsVariableType}");
             }
 
-            yield return new Variable($"{variable.Name}.Client", ClientId!);
-            yield return new Variable($"{variable.Name}.SubscriptionNumber", SubscriptionNumber!);
-            yield return new Variable($"{variable.Name}.Password", Password!);
-            yield return new Variable($"{variable.Name}.TenantId", TenantId!);
-            yield return new Variable($"{variable.Name}.AzureEnvironment", AzureEnvironment!);
-            yield return new Variable($"{variable.Name}.ActiveDirectoryEndpointBaseUri", ActiveDirectoryEndpointBaseUri!);
-            yield return new Variable($"{variable.Name}.ResourceManagementEndpointBaseUri", ResourceManagementEndpointBaseUri!);
+            yield return new Variable($"{variable.Name}.Client", ClientId);
+            yield return new Variable($"{variable.Name}.SubscriptionNumber", SubscriptionNumber);
+            yield return new Variable($"{variable.Name}.Password", Password);
+            yield return new Variable($"{variable.Name}.TenantId", TenantId);
+            yield return new Variable($"{variable.Name}.AzureEnvironment", AzureEnvironment);
+            yield return new Variable($"{variable.Name}.ActiveDirectoryEndpointBaseUri", ActiveDirectoryEndpointBaseUri);
+            yield return new Variable($"{variable.Name}.ResourceManagementEndpointBaseUri", ResourceManagementEndpointBaseUri);
         }
 
         public IEnumerable<(string property, bool isSensitive)> GetVariableReferencePropertiesToExpand(VariableType variableType)

--- a/source/Sashimi.AzureCloudService/AzureSubscriptionDetails.cs
+++ b/source/Sashimi.AzureCloudService/AzureSubscriptionDetails.cs
@@ -29,9 +29,9 @@ namespace Sashimi.AzureCloudService
 
         public override IEnumerable<Variable> ContributeVariables()
         {
-            yield return new Variable(SpecialVariables.Action.Azure.SubscriptionId, SubscriptionNumber!);
+            yield return new Variable(SpecialVariables.Action.Azure.SubscriptionId, SubscriptionNumber);
             yield return new Variable(SpecialVariables.Action.Azure.CertificateBytes, CertificateBytes!.Value, VariableType.Sensitive);
-            yield return new Variable(SpecialVariables.Action.Azure.CertificateThumbprint, CertificateThumbprint!);
+            yield return new Variable(SpecialVariables.Action.Azure.CertificateThumbprint, CertificateThumbprint);
 
             if (!String.IsNullOrWhiteSpace(AzureEnvironment))
             {
@@ -57,10 +57,10 @@ namespace Sashimi.AzureCloudService
             }
 
             yield return new Variable($"{variable.Name}.CertificateThumbprint", CertificateThumbprint!, VariableType.Sensitive);
-            yield return new Variable($"{variable.Name}.SubscriptionNumber", SubscriptionNumber!);
-            yield return new Variable($"{variable.Name}.AzureEnvironment", AzureEnvironment!);
-            yield return new Variable($"{variable.Name}.ServiceManagementEndpointBaseUri", ServiceManagementEndpointBaseUri!);
-            yield return new Variable($"{variable.Name}.ServiceManagementEndpointSuffix", ServiceManagementEndpointSuffix!);
+            yield return new Variable($"{variable.Name}.SubscriptionNumber", SubscriptionNumber);
+            yield return new Variable($"{variable.Name}.AzureEnvironment", AzureEnvironment);
+            yield return new Variable($"{variable.Name}.ServiceManagementEndpointBaseUri", ServiceManagementEndpointBaseUri);
+            yield return new Variable($"{variable.Name}.ServiceManagementEndpointSuffix", ServiceManagementEndpointSuffix);
         }
 
         [JsonIgnore]

--- a/source/Sashimi.AzureServiceFabric/Endpoints/AzureServiceFabricClusterEndpoint.cs
+++ b/source/Sashimi.AzureServiceFabric/Endpoints/AzureServiceFabricClusterEndpoint.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using Octopus.Data.Model;
 using Sashimi.Server.Contracts;
@@ -15,17 +14,17 @@ namespace Sashimi.AzureServiceFabric.Endpoints
         public override DeploymentTargetType DeploymentTargetType { get; } = AzureServiceFabricClusterDeploymentTargetType;
         public override string Description => ConnectionEndpoint;
 
-        public string ConnectionEndpoint { get; set; }
+        public string ConnectionEndpoint { get; set; } = string.Empty;
         public AzureServiceFabricSecurityMode SecurityMode { get; set; }
-        public string ServerCertThumbprint { get; set; }
-        public string ClientCertVariable { get; set; }
-        public string CertificateStoreLocation { get; set; }
-        public string CertificateStoreName { get; set; }
-        public AzureServiceFabricCredentialType AadCredentialType { get; set; }
-        public string AadClientCredentialSecret { get; set; }
-        public string AadUserCredentialUsername { get; set; }
+        public string? ServerCertThumbprint { get; set; }
+        public string? ClientCertVariable { get; set; }
+        public string? CertificateStoreLocation { get; set; }
+        public string? CertificateStoreName { get; set; }
+        public AzureServiceFabricCredentialType? AadCredentialType { get; set; }
+        public string? AadClientCredentialSecret { get; set; }
+        public string? AadUserCredentialUsername { get; set; }
 
-        public SensitiveString AadUserCredentialPassword { get; set; }
+        public SensitiveString? AadUserCredentialPassword { get; set; }
 
         public override IEnumerable<Variable> ContributeVariables()
         {
@@ -48,7 +47,7 @@ namespace Sashimi.AzureServiceFabric.Endpoints
             }
         }
 
-        public string DefaultWorkerPoolId { get; set;  }
+        public string DefaultWorkerPoolId { get; set; } = string.Empty;
 
         public override IEnumerable<(string id, DocumentType documentType)> GetRelatedDocuments()
         {

--- a/source/Sashimi.AzureWebApp/Endpoints/AzureWebAppEndpoint.cs
+++ b/source/Sashimi.AzureWebApp/Endpoints/AzureWebAppEndpoint.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Sashimi.Server.Contracts;
 using Sashimi.Server.Contracts.Endpoints;
 using Sashimi.Server.Contracts.Variables;
@@ -15,11 +14,11 @@ namespace Sashimi.AzureWebApp.Endpoints
 
         public override bool ScriptConsoleSupported => true;
 
-        public string AccountId { get; set; }
+        public string AccountId { get; set; } = string.Empty;
 
-        public string WebAppName { get; set; }
-        public string ResourceGroupName { get; set; }
-        public string WebAppSlotName { get; set; }
+        public string WebAppName { get; set; } = string.Empty;
+        public string ResourceGroupName { get; set; } = string.Empty;
+        public string? WebAppSlotName { get; set; } = string.Empty;
 
         public override IEnumerable<Variable> ContributeVariables()
         {
@@ -37,6 +36,6 @@ namespace Sashimi.AzureWebApp.Endpoints
                 yield return (DefaultWorkerPoolId, DocumentType.WorkerPool);
         }
 
-        public string DefaultWorkerPoolId { get; set; }
+        public string DefaultWorkerPoolId { get; set; } = string.Empty;
     }
 }

--- a/source/Sashimi.Tests.Shared/Server/ActionHandlerTestBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/ActionHandlerTestBuilder.cs
@@ -39,7 +39,7 @@ namespace Sashimi.Tests.Shared.Server
     public class ActionHandlerTestBuilder<TCalamariProgram> 
         where TCalamariProgram : CalamariFlavourProgram
     {
-        List<Action<TestActionHandlerContext<TCalamariProgram>>>? arrangeActions;
+        readonly List<Action<TestActionHandlerContext<TCalamariProgram>>> arrangeActions;
         Action<TestActionHandlerResult>? assertAction;
         Type actionHandlerType;
 
@@ -51,7 +51,7 @@ namespace Sashimi.Tests.Shared.Server
 
         public ActionHandlerTestBuilder<TCalamariProgram> WithArrange(Action<TestActionHandlerContext<TCalamariProgram>> arrange)
         {
-            arrangeActions!.Add(arrange);
+            arrangeActions.Add(arrange);
             return this;
         }
 
@@ -70,7 +70,7 @@ namespace Sashimi.Tests.Shared.Server
             var commandBuilder = new TestCalamariCommandBuilder<TCalamariProgram>();
             var context = new TestActionHandlerContext<TCalamariProgram>(commandBuilder, container.Resolve<Octopus.Diagnostics.ILog>());
 
-            foreach (var arrangeAction in arrangeActions!)
+            foreach (var arrangeAction in arrangeActions)
             {
                 arrangeAction?.Invoke(context);    
             }

--- a/source/Server.Contracts/Variables/Variable.cs
+++ b/source/Server.Contracts/Variables/Variable.cs
@@ -16,15 +16,15 @@ namespace Sashimi.Server.Contracts.Variables
             Type = type;
         }
 
-        public Variable(string name, SensitiveString value)
+        public Variable(string name, SensitiveString? value)
         {
             Name = name;
-            Value = value.Value;
+            Value = value?.Value;
             Type = VariableType.Sensitive;
         }
 
         public string Name { get; }
-        public string Value { get; }
+        public string? Value { get; }
         public VariableType Type { get; }
     }
 }

--- a/source/Server.Contracts/Variables/Variable.cs
+++ b/source/Server.Contracts/Variables/Variable.cs
@@ -4,12 +4,12 @@ namespace Sashimi.Server.Contracts.Variables
 {
     public class Variable
     {
-        public Variable(string name, string value)
+        public Variable(string name, string? value)
             : this(name, value, VariableType.String)
         {
         }
 
-        public Variable(string name, string value, VariableType type)
+        public Variable(string name, string? value, VariableType type)
         {
             Name = name;
             Value = value;


### PR DESCRIPTION
The Variable class was assume it was always going to get a non-null for SensitiveStrings. This isn't a correct assumption, the object can be null in server. If it isn't null, it's Value property is guaranteed not null (but it could contain an empty string).

This changes the nullable on the ctor parameter and the Variable.Value property. Should `Variable.Value` be nullable or should the ctor set it to string.Empty when the SensitiveString is null?