### PR TITLE
Fix bug where you can't resave an Azure managed certificate account

### DIFF
--- a/source/Sashimi.AzureCloudService.Tests/AzureCloudServiceEndpointValidatorFixture.cs
+++ b/source/Sashimi.AzureCloudService.Tests/AzureCloudServiceEndpointValidatorFixture.cs
@@ -1,7 +1,13 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Calamari.Tests.Shared;
 using FluentAssertions;
 using FluentValidation;
 using NUnit.Framework;
+using Octopus.Data.Resources;
 using Sashimi.AzureCloudService.Endpoints;
+using Sashimi.Server.Contracts.Accounts;
 using Sashimi.Tests.Shared.Extensions;
 
 namespace Sashimi.AzureCloudService.Tests
@@ -38,6 +44,74 @@ namespace Sashimi.AzureCloudService.Tests
             var errors = sut.ValidateAndGetErrors(endpoint);
 
             errors.Should().BeEmpty();
+        }
+    }
+
+    public class AzureCertificateRequiresPrivateKeyFixture
+    {
+        AzureCertificateRequiresPrivateKey sut;
+        CertificateEncoder certificateEncoder;
+
+        [SetUp]
+        public void SetUp()
+        {
+            certificateEncoder = new CertificateEncoder(new ServerInMemoryLog());
+            sut = new AzureCertificateRequiresPrivateKey(certificateEncoder);
+        }
+
+        [Test]
+        public void CanContribute_AzureSubscriptionAccountResource_True()
+        {
+            sut.CanContribute(new AzureSubscriptionAccountResource()).Should().BeTrue();
+        }
+
+        [Test]
+        public void CanContribute_NotAzureSubscriptionAccountResource_False()
+        {
+            sut.CanContribute(new TestAccountDetailsResource()).Should().BeFalse();
+        }
+
+        [Test]
+        public void ValidateResource_NoCertificate_Success()
+        {
+            sut.ValidateResource(new AzureSubscriptionAccountResource()).IsValid.Should().BeTrue();
+        }
+
+        [Test]
+        public void ValidateResource_CertificateWithPrivateKey_Success()
+        {
+            var accountResource = new AzureSubscriptionAccountResource();
+            accountResource.CertificateBytes = certificateEncoder.ToBase64String(GenerateCertificate());
+
+            sut.ValidateResource(accountResource).IsValid.Should().BeTrue();
+        }
+
+        [Test]
+        public void ValidateResource_CertificateWithoutPrivateKey_Error()
+        {
+            var accountResource = new AzureSubscriptionAccountResource();
+
+            var cert = GenerateCertificate();
+
+            accountResource.CertificateBytes = new SensitiveValue()
+            {
+                HasValue = true,
+                NewValue = Convert.ToBase64String(cert.Export(X509ContentType.Cert))
+            };
+
+            var result = sut.ValidateResource(accountResource);
+            result.IsValid.Should().BeFalse();
+            result.ErrorMessage.Should().Be("The X509 Certificate file lacks the private key. Please provide a file that includes the private key.");
+        }
+
+        static X509Certificate2 GenerateCertificate()
+        {
+            return new CertificateGenerator().GenerateNew(CertificateExpectations.BuildOctopusAzureCertificateFullName("blah"));
+        }
+
+        class TestAccountDetailsResource : AccountDetailsResource
+        {
+            public override AccountType AccountType => new AccountType("blah");
         }
     }
 }

--- a/source/Sashimi.AzureCloudService/AzureCertificateRequiresPrivateKey.cs
+++ b/source/Sashimi.AzureCloudService/AzureCertificateRequiresPrivateKey.cs
@@ -16,19 +16,18 @@ namespace Sashimi.AzureCloudService
             return resource is AzureSubscriptionAccountResource;
         }
 
-        public override bool ValidateResource(AccountDetailsResource accountResource, out string errorMessage)
+        public override ValidationResult ValidateResource(AccountDetailsResource accountResource)
         {
-            errorMessage = "The X509 Certificate file lacks the private key. Please provide a file that includes the private key.";
-            var resource = (AzureSubscriptionAccountResource)accountResource;
-            if (string.IsNullOrWhiteSpace(resource.CertificateBytes.NewValue))
+            var resource = (AzureSubscriptionAccountResource) accountResource;
+            if (!string.IsNullOrWhiteSpace(resource.CertificateBytes.NewValue))
             {
-                return true;
+                var cert = certificateEncoder.FromBase64String(resource.CertificateBytes.NewValue);
+
+                if (!cert.HasPrivateKey)
+                    return ValidationResult.Error("The X509 Certificate file lacks the private key. Please provide a file that includes the private key.");
             }
 
-            var cert = certificateEncoder.FromBase64String(resource.CertificateBytes.NewValue);
-
-            return cert.HasPrivateKey;
+            return ValidationResult.Success;
         }
-
     }
 }

--- a/source/Sashimi.AzureCloudService/AzureCertificateRequiresPrivateKey.cs
+++ b/source/Sashimi.AzureCloudService/AzureCertificateRequiresPrivateKey.cs
@@ -22,7 +22,7 @@ namespace Sashimi.AzureCloudService
             var resource = (AzureSubscriptionAccountResource)accountResource;
             if (string.IsNullOrWhiteSpace(resource.CertificateBytes.NewValue))
             {
-                return false;
+                return true;
             }
 
             var cert = certificateEncoder.FromBase64String(resource.CertificateBytes.NewValue);

--- a/source/Server.Contracts/Accounts/AccountStoreContributor.cs
+++ b/source/Server.Contracts/Accounts/AccountStoreContributor.cs
@@ -7,10 +7,9 @@ namespace Sashimi.Server.Contracts.Accounts
             return false;
         }
 
-        public virtual bool ValidateResource(AccountDetailsResource resource, out string errorMessage)
+        public virtual ValidationResult ValidateResource(AccountDetailsResource resource)
         {
-            errorMessage = null!;
-            return true;
+            return ValidationResult.Success;
         }
 
         public virtual void ModifyResource(AccountDetailsResource accountResource, string name)
@@ -20,5 +19,24 @@ namespace Sashimi.Server.Contracts.Accounts
         public virtual void ModifyModel(AccountDetailsResource resource, AccountDetails model, string name)
         {
         }
+    }
+
+    public class ValidationResult
+    {
+        public static readonly ValidationResult Success = new ValidationResult(true, null);
+
+        public static ValidationResult Error(string errorMessage)
+        {
+            return new ValidationResult(false, errorMessage);
+        }
+
+        ValidationResult(bool isValid, string? errorMessage)
+        {
+            IsValid = isValid;
+            ErrorMessage = errorMessage;
+        }
+
+        public bool IsValid { get; }
+        public string? ErrorMessage { get; }
     }
 }


### PR DESCRIPTION
The validation logic was back to front. We should allow empty/null values