### PR TITLE
Tweak Terraform logging so the variable name can be copy/pasted directly

### DIFF
--- a/source/Calamari.Terraform/ApplyCommand.cs
+++ b/source/Calamari.Terraform/ApplyCommand.cs
@@ -23,7 +23,7 @@ namespace Calamari.Terraform
             this.fileSystem = fileSystem;
             this.commandLineRunner = commandLineRunner;
         }
-        
+
         protected override void Execute(RunningDeployment deployment, Dictionary<string, string> environmentVariables)
         {
             using (var cli = new TerraformCliExecutor(log, fileSystem, commandLineRunner, deployment, environmentVariables))
@@ -44,7 +44,7 @@ namespace Calamari.Terraform
 
                     var json = token.ToString();
                     var value = token.SelectToken("value")?.ToString();
-                    
+
                     log.SetOutputVariable($"TerraformJsonOutputs[{name}]", json, deployment.Variables, isSensitive);
                     if (value != null)
                     {
@@ -52,11 +52,11 @@ namespace Calamari.Terraform
                     }
 
                     log.Info(
-                        $"Saving {(isSensitive ? "sensitive" : String.Empty)}variable 'Octopus.Action[\"{deployment.Variables["Octopus.Action.StepName"]}\"].Output.TerraformJsonOutputs[\"{name}\"]' with the JSON value only of '{json}'");
+                        $"Saving {(isSensitive ? "sensitive " : String.Empty)}variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.TerraformJsonOutputs[\"{name}\"]' with the JSON value only of '{json}'");
                     if (value != null)
                     {
                         log.Info(
-                            $"Saving {(isSensitive ? "sensitive" : String.Empty)}variable 'Octopus.Action[\"{deployment.Variables["Octopus.Action.StepName"]}\"].Output.TerraformValueOutputs[\"{name}\"]' with the value only of '{value}'");
+                            $"Saving {(isSensitive ? "sensitive " : String.Empty)}variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.TerraformValueOutputs[\"{name}\"]' with the value only of '{value}'");
                     }
                 }
             }

--- a/source/Calamari.Terraform/PlanCommand.cs
+++ b/source/Calamari.Terraform/PlanCommand.cs
@@ -14,10 +14,10 @@ namespace Calamari.Terraform
         readonly ICalamariFileSystem fileSystem;
         readonly ICommandLineRunner commandLineRunner;
 
-        public PlanCommand(ILog log, 
-            IVariables variables, 
-            ICalamariFileSystem fileSystem, 
-            ICommandLineRunner commandLineRunner, 
+        public PlanCommand(ILog log,
+            IVariables variables,
+            ICalamariFileSystem fileSystem,
+            ICommandLineRunner commandLineRunner,
             ISubstituteInFiles substituteInFiles,
             IExtractPackage extractPackage)
             : base(log, variables, fileSystem, substituteInFiles, extractPackage)
@@ -43,12 +43,12 @@ namespace Calamari.Terraform
                 }
 
                 log.Info(
-                    $"Saving variable 'Octopus.Action[\"{deployment.Variables["Octopus.Action.StepName"]}\"].Output.{TerraformSpecialVariables.Action.Terraform.PlanDetailedExitCode}' with the detailed exit code of the plan, with value '{resultCode}'.");
+                    $"Saving variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.{TerraformSpecialVariables.Action.Terraform.PlanDetailedExitCode}' with the detailed exit code of the plan, with value '{resultCode}'.");
                 log.SetOutputVariable(TerraformSpecialVariables.Action.Terraform.PlanDetailedExitCode, resultCode.ToString(), deployment.Variables);
             }
 
             log.Info(
-                $"Saving variable 'Octopus.Action[\"{deployment.Variables["Octopus.Action.StepName"]}\"].Output.{TerraformSpecialVariables.Action.Terraform.PlanOutput}' with the details of the plan");
+                $"Saving variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.{TerraformSpecialVariables.Action.Terraform.PlanOutput}' with the details of the plan");
             log.SetOutputVariable(TerraformSpecialVariables.Action.Terraform.PlanOutput, results, deployment.Variables);
         }
     }


### PR DESCRIPTION
Basically reapplying https://github.com/OctopusDeploy/Sashimi/pull/7 by removing the quotes around parts of the variable name when logging.