### PR TITLE
Move shared AWS special variables into Aws.Accounts

### DIFF
--- a/source/Sashimi.Aws.Accounts/SpecialVariables.cs
+++ b/source/Sashimi.Aws.Accounts/SpecialVariables.cs
@@ -21,6 +21,7 @@ namespace Sashimi.Aws.Accounts
                 public static readonly string AssumedRoleSession = "Octopus.Action.Aws.AssumedRoleSession";
                 public static readonly string AssumeRoleSessionDurationSeconds = "Octopus.Action.Aws.AssumeRoleSessionDurationSeconds";
                 public static readonly string IamCapabilities = "Octopus.Action.Aws.IamCapabilities";
+                public static readonly string AssumeRoleExternalId = "Octopus.Action.Aws.AssumeRoleExternalId";
             }
         }
     }

--- a/source/Sashimi.Aws.Accounts/SpecialVariables.cs
+++ b/source/Sashimi.Aws.Accounts/SpecialVariables.cs
@@ -1,13 +1,26 @@
 namespace Sashimi.Aws.Accounts
 {
-    class SpecialVariables
+    public class SpecialVariables
     {
         public static class Action
         {
-            public static class Amazon
+            //We will make this public once we remove the Server version (we need to contribute these special variables via IContributeSpecialVariables)
+            internal static class Amazon
             {
                 public static readonly string AccessKey = "Octopus.Action.Amazon.AccessKey";
                 public static readonly string SecretKey = "Octopus.Action.Amazon.SecretKey";
+            }
+
+            public static class Aws
+            {
+                public static readonly string AccountId = "Octopus.Action.AwsAccount.Variable";
+                public static readonly string UseInstanceRole = "Octopus.Action.AwsAccount.UseInstanceRole";
+                public static readonly string AwsRegion = "Octopus.Action.Aws.Region";
+                public static readonly string AssumeRole = "Octopus.Action.Aws.AssumeRole";
+                public static readonly string AssumedRoleArn = "Octopus.Action.Aws.AssumedRoleArn";
+                public static readonly string AssumedRoleSession = "Octopus.Action.Aws.AssumedRoleSession";
+                public static readonly string AssumeRoleSessionDurationSeconds = "Octopus.Action.Aws.AssumeRoleSessionDurationSeconds";
+                public static readonly string IamCapabilities = "Octopus.Action.Aws.IamCapabilities";
             }
         }
     }

--- a/source/Sashimi.Aws.Tests/RunScript/AwsRunScriptActionHandlerFixture.cs
+++ b/source/Sashimi.Aws.Tests/RunScript/AwsRunScriptActionHandlerFixture.cs
@@ -3,6 +3,7 @@ using NSubstitute;
 using NSubstitute.Extensions;
 using NUnit.Framework;
 using Octopus.Diagnostics;
+using Sashimi.Aws.Accounts;
 using Sashimi.Aws.ActionHandler;
 using Sashimi.Server.Contracts;
 using Sashimi.Server.Contracts.ActionHandlers;
@@ -69,10 +70,10 @@ namespace Sashimi.Aws.Tests.RunScript
                 {
                     context.Variables.Add(KnownVariables.Action.Script.ScriptSource, "Inline");
                     context.Variables.Add(KnownVariables.Action.Script.Syntax, ScriptSyntax.PowerShell.ToString());
-                    context.Variables.Add(AwsSpecialVariables.Action.Aws.AssumeRole, bool.FalseString);
-                    context.Variables.Add(AwsSpecialVariables.Action.Aws.UseInstanceRole, bool.FalseString);
-                    context.Variables.Add(AwsSpecialVariables.Action.Aws.AwsRegion, "us-east-1");
-                    context.Variables.Add(AwsSpecialVariables.Action.Aws.AccountId, "AWS Account Variable");
+                    context.Variables.Add(SpecialVariables.Action.Aws.AssumeRole, bool.FalseString);
+                    context.Variables.Add(SpecialVariables.Action.Aws.UseInstanceRole, bool.FalseString);
+                    context.Variables.Add(SpecialVariables.Action.Aws.AwsRegion, "us-east-1");
+                    context.Variables.Add(SpecialVariables.Action.Aws.AccountId, "AWS Account Variable");
                     context.Variables.Add(KnownVariables.Action.Script.ScriptBody, "aws sts get-caller-identity");
                     context.WithAwsAccount();
                 })
@@ -90,10 +91,10 @@ namespace Sashimi.Aws.Tests.RunScript
                 {
                     context.Variables.Add(KnownVariables.Action.Script.ScriptSource, "Inline");
                     context.Variables.Add(KnownVariables.Action.Script.Syntax, ScriptSyntax.PowerShell.ToString());
-                    context.Variables.Add(AwsSpecialVariables.Action.Aws.AssumeRole, bool.FalseString);
-                    context.Variables.Add(AwsSpecialVariables.Action.Aws.UseInstanceRole, bool.FalseString);
-                    context.Variables.Add(AwsSpecialVariables.Action.Aws.AwsRegion, "us-east-1");
-                    context.Variables.Add(AwsSpecialVariables.Action.Aws.AccountId, "AWS Account Variable");
+                    context.Variables.Add(SpecialVariables.Action.Aws.AssumeRole, bool.FalseString);
+                    context.Variables.Add(SpecialVariables.Action.Aws.UseInstanceRole, bool.FalseString);
+                    context.Variables.Add(SpecialVariables.Action.Aws.AwsRegion, "us-east-1");
+                    context.Variables.Add(SpecialVariables.Action.Aws.AccountId, "AWS Account Variable");
                     context.Variables.Add(KnownVariables.Action.Script.ScriptBody, "Get-STSCallerIdentity | Select-Object -Property *");
                     context.WithAwsAccount();
                 })

--- a/source/Sashimi.Aws.Tests/RunScript/AwsS3UploadActionHandlerFixture.cs
+++ b/source/Sashimi.Aws.Tests/RunScript/AwsS3UploadActionHandlerFixture.cs
@@ -5,6 +5,7 @@ using Calamari.Aws.Integration.S3;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using NUnit.Framework;
+using Sashimi.Aws.Accounts;
 using Sashimi.Aws.ActionHandler;
 using Sashimi.Aws.Validation;
 using Sashimi.Server.Contracts;
@@ -50,7 +51,7 @@ namespace Sashimi.Aws.Tests.RunScript
                         }, new JsonSerializerSettings {ContractResolver = new CamelCasePropertyNamesContractResolver()}));
                 })
                 .Execute();
-            
+
             CleanUpS3Bucket(bucketName, folderPrefix, region);
         }
 
@@ -61,7 +62,7 @@ namespace Sashimi.Aws.Tests.RunScript
             var region = "ap-southeast-1";
             var folderPrefix = $"test/{Guid.NewGuid().ToString()}/";
             var path = TestEnvironment.GetTestPath(@"AwsS3Sample\AwsS3Sample.1.0.0.nupkg");
-            
+
             ActionHandlerTestBuilder.Create<AwsUploadS3ActionHandler, Program>()
                 .WithArrange(context =>
                 {
@@ -69,7 +70,7 @@ namespace Sashimi.Aws.Tests.RunScript
                     context.Variables.Add("Octopus.Action.Aws.AssumedRoleArn", string.Empty);
                     context.Variables.Add("Octopus.Action.Aws.AssumedRoleSession", string.Empty);
                     context.Variables.Add("Octopus.Action.Aws.Region", region);
-                    context.Variables.Add(AwsSpecialVariables.Action.Aws.UseInstanceRole, bool.FalseString);
+                    context.Variables.Add(SpecialVariables.Action.Aws.UseInstanceRole, bool.FalseString);
                     context.Variables.Add(AwsSpecialVariables.Action.Aws.S3.BucketName, bucketName);
                     context.Variables.Add(AwsSpecialVariables.Action.Aws.S3.TargetMode, S3TargetMode.FileSelections.ToString());
                     context.WithPackage(path);
@@ -113,7 +114,7 @@ namespace Sashimi.Aws.Tests.RunScript
                                 }, new JsonSerializerSettings {ContractResolver = new CamelCasePropertyNamesContractResolver()}));
                 })
                 .Execute();
-            
+
             CleanUpS3Bucket(bucketName, folderPrefix, region);
         }
 
@@ -123,13 +124,13 @@ namespace Sashimi.Aws.Tests.RunScript
                 .WithArrange(context =>
                 {
                     context.WithAwsAccount();
-                    context.Variables.Add(AwsSpecialVariables.Action.Aws.UseInstanceRole, bool.FalseString);
+                    context.Variables.Add(SpecialVariables.Action.Aws.UseInstanceRole, bool.FalseString);
                     context.Variables.Add(KnownVariables.Action.Script.ScriptSource, "Inline");
                     context.Variables.Add(KnownVariables.Action.Script.ScriptBody, $"aws s3 rm s3://{bucketName}/{folderPrefix} --recursive");
-                    context.Variables.Add("Octopus.Action.Aws.AssumeRole", bool.FalseString);
-                    context.Variables.Add("Octopus.Action.Aws.AssumedRoleArn", string.Empty);
-                    context.Variables.Add("Octopus.Action.Aws.AssumedRoleSession", string.Empty);
-                    context.Variables.Add("Octopus.Action.Aws.Region", region);
+                    context.Variables.Add(SpecialVariables.Action.Aws.AssumeRole, bool.FalseString);
+                    context.Variables.Add(SpecialVariables.Action.Aws.AssumedRoleArn, string.Empty);
+                    context.Variables.Add(SpecialVariables.Action.Aws.AssumedRoleSession, string.Empty);
+                    context.Variables.Add(SpecialVariables.Action.Aws.AwsRegion, region);
                 })
                 .Execute(assertWasSuccess: false); // don't fail the test if the cleanup fails
         }

--- a/source/Sashimi.Aws.Tests/TestExtensions.cs
+++ b/source/Sashimi.Aws.Tests/TestExtensions.cs
@@ -42,7 +42,7 @@ namespace Sashimi.Aws.Tests
         public static TestActionHandlerContext<TCalamariProgram> WithAwsRegion<TCalamariProgram>(this TestActionHandlerContext<TCalamariProgram> context, string region)
             where TCalamariProgram : CalamariFlavourProgram
         {
-            context.Variables.Add(AwsSpecialVariables.Action.Aws.AwsRegion, region);
+            context.Variables.Add(SpecialVariables.Action.Aws.AwsRegion, region);
 
             return context;
         }
@@ -81,7 +81,7 @@ namespace Sashimi.Aws.Tests
         public static TestActionHandlerContext<TCalamariProgram> WithIamCapabilities<TCalamariProgram>(this TestActionHandlerContext<TCalamariProgram> context, IEnumerable<string> capabilities)
             where TCalamariProgram : CalamariFlavourProgram
         {
-            context.Variables.Add(AwsSpecialVariables.Action.Aws.IamCapabilities, JsonConvert.SerializeObject(capabilities));
+            context.Variables.Add(SpecialVariables.Action.Aws.IamCapabilities, JsonConvert.SerializeObject(capabilities));
 
             return context;
         }

--- a/source/Sashimi.Aws/AwsSpecialVariables.cs
+++ b/source/Sashimi.Aws/AwsSpecialVariables.cs
@@ -14,13 +14,6 @@
                 }
 
                 public const string WaitForCompletion = "Octopus.Action.Aws.WaitForCompletion";
-                public const string AccountId = "Octopus.Action.AwsAccount.Variable";
-                public const string UseInstanceRole = "Octopus.Action.AwsAccount.UseInstanceRole";
-                public const string AwsRegion = "Octopus.Action.Aws.Region";
-                public const string AssumeRole = "Octopus.Action.Aws.AssumeRole";
-                public const string AssumedRoleArn = "Octopus.Action.Aws.AssumedRoleArn";
-                public const string AssumedRoleSession = "Octopus.Action.Aws.AssumedRoleSession";
-                public const string IamCapabilities = "Octopus.Action.Aws.IamCapabilities";
                 public const string DisableRollback = "Octopus.Action.Aws.DisableRollback";
 
                 public static readonly string UseBundledAwsPowerShellModules = "OctopusUseBundledAwsPowerShellModules";

--- a/source/Sashimi.Aws/Sashimi.Aws.csproj
+++ b/source/Sashimi.Aws/Sashimi.Aws.csproj
@@ -17,6 +17,7 @@
         <EmbeddedResource Include="**\*.sh" />
     </ItemGroup>
     <ItemGroup>
+        <ProjectReference Include="..\Sashimi.Aws.Accounts\Sashimi.Aws.Accounts.csproj" />
         <ProjectReference Include="..\Server.Contracts\Sashimi.Server.Contracts.csproj" />
         <PackageReference Include="YamlDotNet" Version="6.1.2" />
     </ItemGroup>

--- a/source/Sashimi.Aws/Validation/AwsDeploymentValidatorBase.cs
+++ b/source/Sashimi.Aws/Validation/AwsDeploymentValidatorBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FluentValidation;
+using Sashimi.Aws.Accounts;
 using Sashimi.Server.Contracts;
 using Sashimi.Server.Contracts.ActionHandlers.Validation;
 using PropertiesDictionary = System.Collections.Generic.IReadOnlyDictionary<string, string>;
@@ -21,23 +22,23 @@ namespace Sashimi.Aws.Validation
         public virtual void AddDeploymentValidationRule(AbstractValidator<DeploymentActionValidationContext> validator)
         {
             validator.RuleFor(a => a.Properties)
-                .MustHaveProperty(AwsSpecialVariables.Action.Aws.AwsRegion, "Please provide the AWS region that the step will default to.")
+                .MustHaveProperty(SpecialVariables.Action.Aws.AwsRegion, "Please provide the AWS region that the step will default to.")
                 .When(ThisAction);
 
             validator.RuleFor(a => a.Properties)
-                .MustHaveProperty(AwsSpecialVariables.Action.Aws.AssumedRoleArn, $"Please provide the assumed role ARN.")
+                .MustHaveProperty(SpecialVariables.Action.Aws.AssumedRoleArn, $"Please provide the assumed role ARN.")
                 .When(ThisAction)
-                .When(a => a.Properties.ContainsKey(AwsSpecialVariables.Action.Aws.AssumeRole) &&
-                    "True".Equals(a.Properties[AwsSpecialVariables.Action.Aws.AssumeRole], StringComparison.OrdinalIgnoreCase));
+                .When(a => a.Properties.ContainsKey(SpecialVariables.Action.Aws.AssumeRole) &&
+                    "True".Equals(a.Properties[SpecialVariables.Action.Aws.AssumeRole], StringComparison.OrdinalIgnoreCase));
 
             validator.RuleFor(a => a.Properties)
-                .MustHaveProperty(AwsSpecialVariables.Action.Aws.AssumedRoleSession, $"Please provide the assumed role session name.")
+                .MustHaveProperty(SpecialVariables.Action.Aws.AssumedRoleSession, $"Please provide the assumed role session name.")
                 .When(ThisAction)
-                .When(a => a.Properties.ContainsKey(AwsSpecialVariables.Action.Aws.AssumeRole) &&
-                    "True".Equals(a.Properties[AwsSpecialVariables.Action.Aws.AssumeRole], StringComparison.OrdinalIgnoreCase));
+                .When(a => a.Properties.ContainsKey(SpecialVariables.Action.Aws.AssumeRole) &&
+                    "True".Equals(a.Properties[SpecialVariables.Action.Aws.AssumeRole], StringComparison.OrdinalIgnoreCase));
 
             validator.RuleFor(a => a.Properties)
-                .MustHaveProperty(AwsSpecialVariables.Action.Aws.AccountId, "Please specify the AWS account.")
+                .MustHaveProperty(SpecialVariables.Action.Aws.AccountId, "Please specify the AWS account.")
                 .When(ThisAction)
                 .When(a => !IsInstanceRole(a.Properties));
         }
@@ -50,8 +51,8 @@ namespace Sashimi.Aws.Validation
 
         static bool IsInstanceRole(PropertiesDictionary properties)
         {
-            return properties.ContainsKey(AwsSpecialVariables.Action.Aws.UseInstanceRole) &&
-                (properties[AwsSpecialVariables.Action.Aws.UseInstanceRole] ?? "") == "True";
+            return properties.ContainsKey(SpecialVariables.Action.Aws.UseInstanceRole) &&
+                (properties[SpecialVariables.Action.Aws.UseInstanceRole] ?? "") == "True";
         }
     }
 }


### PR DESCRIPTION
Kubernetes needs to reference these account related special variables, so we need to move them to `Sashimi.Aws.Accounts` which is public for all to see.