### PR TITLE
Change return type of HealthCheckActionHandlerForTargetType

### DIFF
--- a/source/Sashimi.AzureCloudService/Endpoints/AzureCloudServiceDeploymentTargetTypeProvider.cs
+++ b/source/Sashimi.AzureCloudService/Endpoints/AzureCloudServiceDeploymentTargetTypeProvider.cs
@@ -29,7 +29,7 @@ namespace Sashimi.AzureCloudService.Endpoints
             builder.Map<CloudServiceEndpointResource, AzureCloudServiceEndpoint>();
         }
 
-        public IActionHandler HealthCheckActionHandlerForTargetType()
+        public IActionHandler? HealthCheckActionHandlerForTargetType()
         {
             return new AzureCloudServiceHealthCheckActionHandler();
         }

--- a/source/Sashimi.AzureServiceFabric/Endpoints/AzureServiceFabricClusterDeploymentTargetTypeProvider.cs
+++ b/source/Sashimi.AzureServiceFabric/Endpoints/AzureServiceFabricClusterDeploymentTargetTypeProvider.cs
@@ -20,7 +20,7 @@ namespace Sashimi.AzureServiceFabric.Endpoints
         public Type ApiType => typeof(ServiceFabricEndpointResource);
         public IValidator Validator => new AzureServiceFabricClusterEndpointValidator();
 
-        public IActionHandler HealthCheckActionHandlerForTargetType()
+        public IActionHandler? HealthCheckActionHandlerForTargetType()
         {
             return new AzureServiceFabricAppHealthCheckActionHandler();
         }

--- a/source/Sashimi.AzureWebApp/Endpoints/AzureWebAppDeploymentTargetTypeProvider.cs
+++ b/source/Sashimi.AzureWebApp/Endpoints/AzureWebAppDeploymentTargetTypeProvider.cs
@@ -28,7 +28,7 @@ namespace Sashimi.AzureWebApp.Endpoints
             builder.Map<AzureWebAppEndpointResource, AzureWebAppEndpoint>();
         }
 
-        public IActionHandler HealthCheckActionHandlerForTargetType()
+        public IActionHandler? HealthCheckActionHandlerForTargetType()
         {
             return new AzureWebAppHealthCheckActionHandler();
         }

--- a/source/Server.Contracts/Endpoints/IDeploymentTargetTypeProvider.cs
+++ b/source/Server.Contracts/Endpoints/IDeploymentTargetTypeProvider.cs
@@ -12,7 +12,7 @@ namespace Sashimi.Server.Contracts.Endpoints
         DeploymentTargetType DeploymentTargetType { get; }
         Type DomainType { get; }
         Type ApiType { get; }
-        IActionHandler HealthCheckActionHandlerForTargetType();
+        IActionHandler? HealthCheckActionHandlerForTargetType();
         IValidator Validator { get; }
         IEnumerable<AccountType> SupportedAccountTypes { get; }
         IEnumerable<(string key, object value)> GetFeatureUsage(IEndpointMetricContext context);


### PR DESCRIPTION
Change return type of HealthCheckActionHandlerForTargetType to nullable

Reason for this change: Only subset of implementations of IDeploymentTargetTypeProvider needs HealthCheckActionHandlerForTargetType. 