### PR TITLE
Publish Calamari.Tests.Shared and Sashimi.Tests.Shared packages

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -165,7 +165,7 @@ Task("Publish")
     .WithCriteria(BuildSystem.IsRunningOnTeamCity)
     .Does(() =>
 {
-    var packages = GetFiles($"{artifactsDir}Sashimi.*.{nugetVersion}.nupkg");
+    var packages = GetFiles($"{artifactsDir}*.{nugetVersion}.nupkg");
     foreach (var package in packages)
     {
         NuGetPush(package, new NuGetPushSettings {

--- a/source/Calamari.Tests.Shared/Calamari.Tests.Shared.csproj
+++ b/source/Calamari.Tests.Shared/Calamari.Tests.Shared.csproj
@@ -1,16 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>net452;netstandard2.1</TargetFrameworks>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net452;netstandard2.1</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <PackageProjectUrl>https://github.com/OctopusDeploy/Sashimi/</PackageProjectUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Assent" Version="1.6.0" />
-        <PackageReference Include="Calamari.Common" Version="13.0.5" />
-        <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Assent" Version="1.6.0" />
+    <PackageReference Include="Calamari.Common" Version="13.0.5" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
+  </ItemGroup>
 
 </Project>

--- a/source/Sashimi.Tests.Shared/Sashimi.Tests.Shared.csproj
+++ b/source/Sashimi.Tests.Shared/Sashimi.Tests.Shared.csproj
@@ -7,7 +7,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
+    <PackageProjectUrl>https://github.com/OctopusDeploy/Sashimi/</PackageProjectUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Publish & push `Calamari.Tests.Shared` and `Sashimi.Tests.Shared` nuget packages to `feedz.io`, so each individual separated `Sashimi.*` test projects/repo can reference them.