### PR TITLE
Support the new Calamari-like build pipeline

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -133,7 +133,31 @@ Task("PublishCalamariProjects")
         }
 });
 
+Task("PublishSashimiProjects")
+   .IsDependentOn("Build")
+    .Does(() => {
+        var projects = GetFiles("./source/**/Sashimi.*.csproj");
+		foreach(var project in projects)
+        {
+            var sashimiFlavour = project.GetFilenameWithoutExtension().ToString();
+
+                void RunPublish() {
+                     DotNetCorePublish(project.FullPath, new DotNetCorePublishSettings
+		    	    {
+		    	    	Configuration = configuration,
+                        OutputDirectory = $"{publishDir}/{sashimiFlavour}"
+		    	    });
+                }
+
+                RunPublish();
+
+            Console.WriteLine($"{publishDir}/{sashimiFlavour}");
+            Zip($"{publishDir}{sashimiFlavour}", $"{artifactsDir}{sashimiFlavour}.zip");
+        }
+});
+
 Task("PackSashimi")
+    .IsDependentOn("PublishSashimiProjects")
     .IsDependentOn("PublishCalamariProjects")
     .Does(() =>
 {

--- a/build.cake
+++ b/build.cake
@@ -111,7 +111,7 @@ Task("PublishCalamariProjects")
                      DotNetCorePublish(project.FullPath, new DotNetCorePublishSettings
 		    	    {
 		    	    	Configuration = configuration,
-                        OutputDirectory = $"{publishDir}/{calamariFlavour}/{platform}",
+                        OutputDirectory = $"{publishDir}{calamariFlavour}/{platform}",
                         Framework = framework,
                         Runtime = runtime
 		    	    });
@@ -121,15 +121,20 @@ Task("PublishCalamariProjects")
                 {
                     var runtimes = XmlPeek(project, "Project/PropertyGroup/RuntimeIdentifiers").Split(';');
                     foreach(var runtime in runtimes)
+                    {
                         RunPublish(runtime, runtime);
+                        Console.WriteLine($"{publishDir}{calamariFlavour}/{runtime}");
+                        Zip($"{publishDir}{calamariFlavour}/{runtime}", $"{artifactsDir}{calamariFlavour}.{runtime}.zip");
+
+                    }
                 }
                 else
                 {
                     RunPublish(null, "netfx");
+                    Console.WriteLine($"{publishDir}{calamariFlavour}");
+                    Zip($"{publishDir}{calamariFlavour}/netfx", $"{artifactsDir}{calamariFlavour}.zip");
                 }
             }
-            Console.WriteLine($"{publishDir}/{calamariFlavour}");
-            Zip($"{publishDir}{calamariFlavour}", $"{artifactsDir}{calamariFlavour}.zip");
         }
 });
 

--- a/build.cake
+++ b/build.cake
@@ -130,8 +130,8 @@ Task("PublishCalamariProjects")
                     RunPublish(null, "netfx");
                 }
             }
-              Console.WriteLine($"{publishDir}/{calamariFlavour}");
-                        Zip($"{publishDir}{calamariFlavour}", $"{artifactsDir}{calamariFlavour}.zip");
+            Console.WriteLine($"{publishDir}/{calamariFlavour}");
+            Zip($"{publishDir}{calamariFlavour}", $"{artifactsDir}{calamariFlavour}.zip");
         }
 });
 

--- a/build.cake
+++ b/build.cake
@@ -115,26 +115,23 @@ Task("PublishCalamariProjects")
                         Framework = framework,
                         Runtime = runtime
 		    	    });
+                    Console.WriteLine($"{publishDir}{calamariFlavour}/{platform}");
+                    Zip($"{publishDir}{calamariFlavour}/{platform}", $"{artifactsDir}{calamariFlavour}.{platform}.zip");
                 }
 
                 if(framework.StartsWith("netcoreapp"))
                 {
                     var runtimes = XmlPeek(project, "Project/PropertyGroup/RuntimeIdentifiers").Split(';');
                     foreach(var runtime in runtimes)
-                    {
                         RunPublish(runtime, runtime);
-                        Console.WriteLine($"{publishDir}{calamariFlavour}/{runtime}");
-                        Zip($"{publishDir}{calamariFlavour}/{runtime}", $"{artifactsDir}{calamariFlavour}.{runtime}.zip");
-
-                    }
                 }
                 else
                 {
                     RunPublish(null, "netfx");
-                    Console.WriteLine($"{publishDir}{calamariFlavour}");
-                    Zip($"{publishDir}{calamariFlavour}/netfx", $"{artifactsDir}{calamariFlavour}.zip");
                 }
             }
+              Console.WriteLine($"{publishDir}/{calamariFlavour}");
+                        Zip($"{publishDir}{calamariFlavour}", $"{artifactsDir}{calamariFlavour}.zip");
         }
 });
 

--- a/source/Calamari.Aws/DeployAwsCloudFormationCommand.cs
+++ b/source/Calamari.Aws/DeployAwsCloudFormationCommand.cs
@@ -11,6 +11,7 @@ using Calamari.Aws.Util;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Packages;
 using Calamari.Common.Plumbing.Deployment;
+using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Variables;
@@ -48,10 +49,8 @@ namespace Calamari.Aws
             var iamCapabilities = GetValidIamCapabilities();
             var waitForCompletion = variables.GetFlag(SpecialVariableNames.Action.WaitForCompletion);
 
-            var packageFilePath = variables.IsSet(SpecialVariableNames.Package.Id) ? 
-                new PathToPackage(Path.GetFullPath(variables.Get(SpecialVariableNames.Package.Id))) :
-                null;
-            extractPackage.ExtractToStagingDirectory(packageFilePath);
+            PathToPackage pathToPrimaryPackage = variables.GetPathToPrimaryPackage(fileSystem, false);
+            extractPackage.ExtractToStagingDirectory(pathToPrimaryPackage);
 
             var cloudFormationTemplate = GetCloudFormationTemplate();
 
@@ -85,7 +84,7 @@ namespace Calamari.Aws
             }
         }
 
-        //TODO: Refactor ITemplateResolver in Calamari.Common to make it a generic ITemplateResolver<TypeTemplate> so it returns the template directly 
+        //TODO: Refactor ITemplateResolver in Calamari.Common to make it a generic ITemplateResolver<TypeTemplate> so it returns the template directly
         CloudFormationTemplate GetCloudFormationTemplate()
         {
             var isTemplateFilesInPackage = variables.Get(SpecialVariableNames.Aws.CloudFormation.TemplateSource).Equals(SpecialVariableValues.CloudFormation.TemplateSource.Package, StringComparison.OrdinalIgnoreCase);
@@ -132,7 +131,7 @@ namespace Calamari.Aws
         {
             var name = $"octo-{Guid.NewGuid():N}";
 
-            if (bool.TrueString.Equals(variables.Get(SpecialVariableNames.Aws.CloudFormation.ChangeSets.Generate), 
+            if (bool.TrueString.Equals(variables.Get(SpecialVariableNames.Aws.CloudFormation.ChangeSets.Generate),
                 StringComparison.OrdinalIgnoreCase))
             {
                 variables.Set(SpecialVariableNames.Aws.CloudFormation.ChangeSets.Name, name);

--- a/source/Calamari.Aws/Deployment/CloudFormation/CloudFormationObjectExtensions.cs
+++ b/source/Calamari.Aws/Deployment/CloudFormation/CloudFormationObjectExtensions.cs
@@ -35,29 +35,29 @@ namespace Calamari.Aws.Deployment.CloudFormation
                 "DELETE_FAILED",
                 "CREATE_FAILED"
             };
-        
+
         /// Some statuses indicate that the only way forward is to delete the stack and try again.
         /// Here are some of the explanations of the stack states from the docs.
-        /// 
+        ///
         /// CREATE_FAILED: Unsuccessful creation of one or more stacks. View the stack events to see any associated error
         /// messages. Possible reasons for a failed creation include insufficient permissions to work with all resources
-        /// in the stack, parameter values rejected by an AWS service, or a timeout during resource creation. 
-        ///  	
+        /// in the stack, parameter values rejected by an AWS service, or a timeout during resource creation.
+        ///
         /// DELETE_FAILED: Unsuccessful deletion of one or more stacks. Because the delete failed, you might have some
         /// resources that are still running; however, you cannot work with or update the stack. Delete the stack again
-        /// or view the stack events to see any associated error messages. 
-        /// 
+        /// or view the stack events to see any associated error messages.
+        ///
         /// ROLLBACK_COMPLETE: This status exists only after a failed stack creation. It signifies that all operations
         /// from the partially created stack have been appropriately cleaned up. When in this state, only a delete operation
         /// can be performed.
-        /// 
+        ///
         /// ROLLBACK_FAILED: Unsuccessful removal of one or more stacks after a failed stack creation or after an explicitly
         /// canceled stack creation. Delete the stack or view the stack events to see any associated error messages.
-        /// 
+        ///
         /// UPDATE_ROLLBACK_FAILED: Unsuccessful return of one or more stacks to a previous working state after a failed stack
         /// update. When in this state, you can delete the stack or continue rollback. You might need to fix errors before
-        /// your stack can return to a working state. Or, you can contact customer support to restore the stack to a usable state. 
-        /// 
+        /// your stack can return to a working state. Or, you can contact customer support to restore the stack to a usable state.
+        ///
         /// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-describing-stacks.html#w2ab2c15c15c17c11
         static HashSet<string> UnrecoverableStackStatuses =
             new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -109,7 +109,7 @@ namespace Calamari.Aws.Deployment.CloudFormation
             try
             {
                 var response = await client.DescribeStackEventsAsync(new DescribeStackEventsRequest {StackName = stack.Value});
-                
+
                 return response?
                     .StackEvents.OrderByDescending(stackEvent => stackEvent.Timestamp)
                     .FirstOrDefault(stackEvent => predicate == null || predicate(stackEvent))
@@ -156,13 +156,13 @@ namespace Calamari.Aws.Deployment.CloudFormation
             try
             {
                 var result = await client.DescribeStackAsync(stackArn);
-                
+
                 if (result == null)
                 {
                     return StackStatus.DoesNotExist;
                 }
 
-                if (result.StackStatus == null || 
+                if (result.StackStatus == null ||
                     result.StackStatus.Value.EndsWith("_COMPLETE") ||
                     result.StackStatus.Value.EndsWith("_FAILED"))
                 {
@@ -178,6 +178,10 @@ namespace Calamari.Aws.Deployment.CloudFormation
             catch (AmazonCloudFormationException ex) when (ex.ErrorCode == "ValidationError")
             {
                 return StackStatus.DoesNotExist;
+            }
+            catch (AmazonCloudFormationException ex)
+            {
+                throw new Exception($"AmazonCloudFormationException123 Msg: '{ex.Message}', Code: '{ex.ErrorCode}'", ex);
             }
         }
 
@@ -222,7 +226,7 @@ namespace Calamari.Aws.Deployment.CloudFormation
         {
             Guard.NotNull(stack, "Stack should not be null");
             Guard.NotNull(client, "Client should not be null");
-            
+
             var status = await client.StackExistsAsync(stack, StackStatus.DoesNotExist);
             if (status == StackStatus.DoesNotExist || status == StackStatus.Completed)
             {
@@ -236,7 +240,7 @@ namespace Calamari.Aws.Deployment.CloudFormation
                 action?.Invoke(@event);
             } while (await client.StackExistsAsync(stack, StackStatus.Completed) == StackStatus.InProgress);
         }
-                
+
         /// <summary>
         /// Check the stack event status to determine whether it was successful.
         /// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-describing-stacks.html#w2ab2c15c15c17c11

--- a/source/Calamari.Aws/Deployment/CloudFormation/CloudFormationObjectExtensions.cs
+++ b/source/Calamari.Aws/Deployment/CloudFormation/CloudFormationObjectExtensions.cs
@@ -179,9 +179,9 @@ namespace Calamari.Aws.Deployment.CloudFormation
             {
                 return StackStatus.DoesNotExist;
             }
-            catch (AmazonCloudFormationException ex)
+            catch (AmazonCloudFormationException ex) when (ex.ErrorCode == "Throttling")
             {
-                throw new Exception($"AmazonCloudFormationException123 Msg: '{ex.Message}', Code: '{ex.ErrorCode}'", ex);
+                return defaultValue;
             }
         }
 

--- a/source/Calamari.Aws/Deployment/CloudFormation/CloudFormationService.cs
+++ b/source/Calamari.Aws/Deployment/CloudFormation/CloudFormationService.cs
@@ -200,6 +200,11 @@ namespace Calamari.Aws.Deployment.CloudFormation
 
                 return changeSet;
             }
+            catch (AmazonCloudFormationException ex)
+            {
+                log.Warn($"CF Exception: {ex.Message}, code: '{ex.ErrorCode}'");
+                throw;
+            }
             catch (AmazonServiceException exception)
             {
                 LogAmazonServiceException(exception);

--- a/source/Calamari.Aws/UploadAwsS3Command.cs
+++ b/source/Calamari.Aws/UploadAwsS3Command.cs
@@ -73,10 +73,10 @@ namespace Calamari.Aws
             bucketName = variables.Get(SpecialVariableNames.Aws.S3.BucketName)?.Trim();
             Guard.NotNullOrWhiteSpace(bucketName, "Bucket name should not be null or empty");
 
-            pathToPackage = new PathToPackage(Path.GetFullPath(variables.Get(SpecialVariableNames.Package.Id)));
+            pathToPackage = variables.GetPathToPrimaryPackage(fileSystem, false);
             s3TargetMode = GetS3TargetMode(variables.Get(SpecialVariableNames.Aws.S3.TargetMode));
             isMd5HashSupported = HashCalculator.IsAvailableHashingAlgorithm(MD5.Create);
-            
+
             if (s3TargetMode == S3TargetMode.FileSelections)
             {
                 extractPackage.ExtractToStagingDirectory(pathToPackage);
@@ -89,7 +89,7 @@ namespace Calamari.Aws
         async Task EnsureS3BucketExists()
         {
             var client = await amazonS3Client.Value;
-            
+
             if (await Amazon.S3.Util.AmazonS3Util.DoesS3BucketExistV2Async(client, bucketName))
             {
                 log.Verbose($"Bucket {bucketName} exists in region {client.Config.RegionEndpoint}. Skipping creation.");
@@ -178,7 +178,7 @@ namespace Calamari.Aws
         {
             log.SetOutputVariableButDoNotAddToVariables(PackageVariables.Output.FileName, Path.GetFileName(deployment.PackageFilePath));
             log.SetOutputVariableButDoNotAddToVariables(PackageVariables.Output.FilePath, deployment.PackageFilePath);
-            
+
             foreach (var result in results)
             {
                 if (!result.IsSuccess()) continue;
@@ -281,7 +281,7 @@ namespace Calamari.Aws
 
             var request = CreateRequest(filePath, GetBucketKey(filePath.AsRelativePathFrom(deployment.StagingDirectory), selection), selection);
             LogPutObjectRequest(filePath, request);
-            
+
             return await HandleUploadRequest(client, request, ThrowInvalidFileUpload);
         }
 
@@ -313,7 +313,7 @@ namespace Calamari.Aws
         }
 
         /// <summary>
-        /// Creates an upload file request based on the s3 target properties for a given file and bucket key. 
+        /// Creates an upload file request based on the s3 target properties for a given file and bucket key.
         /// </summary>
         /// <param name="path"></param>
         /// <param name="bucketKey"></param>
@@ -390,7 +390,7 @@ namespace Calamari.Aws
                         ex.Message + "\n");
 
                 if (!perFileUploadErrors.ContainsKey(ex.ErrorCode)) throw;
-                
+
                 errorAction(ex, perFileUploadErrors[ex.ErrorCode](request, ex));
 
                 return new S3UploadResult(request, Maybe<PutObjectResponse>.None);

--- a/source/Calamari.Tests.Shared/EnvironmentVariables.cs
+++ b/source/Calamari.Tests.Shared/EnvironmentVariables.cs
@@ -47,10 +47,10 @@ namespace Calamari.Tests.Shared
         [EnvironmentVariable("DockerHub_TestReaderAccount_Password", "Password for DockerHub Test reader account")]
         DockerReaderPassword,
 
-        [EnvironmentVariable("AWS.E2E.AccessKeyId", "AWS E2E Test User Keys")]
+        [EnvironmentVariable("AWS_E2E_AccessKeyId", "AWS E2E Test User Keys")]
         AwsCloudFormationAndS3AccessKey,
 
-        [EnvironmentVariable("AWS.E2E.SecretKeyId", "AWS E2E Test User Keys")]
+        [EnvironmentVariable("AWS_E2E_SecretKeyId", "AWS E2E Test User Keys")]
         AwsCloudFormationAndS3SecretKey
     }
 

--- a/source/Calamari.Tests.Shared/Helpers/CalamariResult.cs
+++ b/source/Calamari.Tests.Shared/Helpers/CalamariResult.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Calamari.Integration.ServiceMessages;
+using Calamari.Util;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+
+namespace Calamari.Tests.Helpers
+{
+    public class CalamariResult
+    {
+        private readonly int exitCode;
+        private readonly CaptureCommandInvocationOutputSink captured;
+
+        public CalamariResult(int exitCode, CaptureCommandInvocationOutputSink captured)
+        {
+            this.exitCode = exitCode;
+            this.captured = captured;
+        }
+
+        public int ExitCode
+        {
+            get { return exitCode; }
+        }
+
+        public CaptureCommandInvocationOutputSink CapturedOutput
+        {
+            get { return captured; }
+        }
+
+        public void AssertSuccess()
+        {
+            var capturedErrors = string.Join(Environment.NewLine, captured.Errors);
+            Assert.That(ExitCode, Is.EqualTo(0), string.Format("Expected command to return exit code 0, instead returned {2}{0}{0}Output:{0}{1}", Environment.NewLine, capturedErrors, ExitCode));
+        }
+
+        public void AssertFailure()
+        {
+            Assert.That(ExitCode, Is.Not.EqualTo(0), "Expected a non-zero exit code");
+        }
+
+
+        public void AssertFailure(int code)
+        {
+            Assert.That(ExitCode, Is.EqualTo(code), $"Expected an exit code of {code}");
+        }
+
+        public void AssertOutput(string expectedOutputFormat, params object[] args)
+        {
+            AssertOutput(String.Format(expectedOutputFormat, args));
+        }
+
+        public void AssertOutputVariable(string name, IResolveConstraint resolveConstraint)
+        {
+            var variable = captured.OutputVariables.Get(name);
+            Assert.That(variable, resolveConstraint);
+        }
+
+        public void AssertServiceMessage(string name, IResolveConstraint resolveConstraint = null, Dictionary<string, object> properties = null, string message = "", params object[] args)
+        {
+            switch (name)
+            {
+                case ServiceMessageNames.CalamariFoundPackage.Name:
+                    Assert.That(captured.CalamariFoundPackage, resolveConstraint, message, args);
+                    break;
+                case ServiceMessageNames.FoundPackage.Name:
+                    Assert.That(captured.FoundPackage, Is.Not.Null);
+                    if (properties != null)
+                    {
+                        Assert.That(resolveConstraint, Is.Not.Null, "Resolve constraint was not provided");
+                        foreach (var property in properties)
+                        {
+                            var fp = JObject.FromObject(captured.FoundPackage);
+                            string value;
+                            if (property.Key.Contains("."))
+                            {
+                                var props = property.Key.Split(new[] {'.'}, StringSplitOptions.RemoveEmptyEntries);
+                                value = fp[props[0]][props[1]].ToString();
+                            }
+                            else
+                            {
+                                value = fp[property.Key].ToString();
+                            }
+
+                            AssertServiceMessageValue(property.Key, property.Value, value, resolveConstraint);
+                        }
+                    }
+
+                    break;
+                case ServiceMessageNames.PackageDeltaVerification.Name:
+                    if (!string.IsNullOrWhiteSpace(message))
+                    {
+                        Assert.That(captured.DeltaError.Replace("\r\n", "\n"), Is.EqualTo(message));
+                        break;
+                    }
+
+                    Assert.That(captured.DeltaVerification, Is.Not.Null);
+                    if (properties != null)
+                    {
+                        foreach (var property in properties)
+                        {
+                            var dv = JObject.FromObject(captured.DeltaVerification);
+                            string value;
+                            if (property.Key.Contains("."))
+                            {
+                                var props = property.Key.Split(new[] {'.'}, StringSplitOptions.RemoveEmptyEntries);
+                                value = dv[props[0]][props[1]].ToString();
+                            }
+                            else
+                            {
+                                value = dv[property.Key].ToString();
+                            }
+
+                            AssertServiceMessageValue(property.Key, property.Value, value, resolveConstraint);
+                        }
+                    }
+
+                    break;
+            }
+        }
+
+        static void AssertServiceMessageValue(string property, object expected, string actual, IResolveConstraint resolveConstraint)
+        {
+            Assert.That(actual, Is.Not.Null);
+            Assert.That(actual, Is.Not.Empty);
+            Assert.That(actual.Equals(expected), resolveConstraint,
+                "Expected property '{0}' to have value '{1}' but was actually '{2}'", property,
+                expected, actual);
+        }
+
+        public void AssertNoOutput(string expectedOutput)
+        {
+            var allOutput = string.Join(Environment.NewLine, captured.Infos);
+
+            Assert.That(allOutput, Does.Not.Contain(expectedOutput));
+        }
+
+        public void AssertOutput(string expectedOutput)
+        {
+            var allOutput = string.Join(Environment.NewLine, captured.Infos);
+
+            Assert.That(allOutput, Does.Contain(expectedOutput));
+        }
+
+        public void AssertOutputContains(string expected)
+        {
+            var allOutput = string.Join(Environment.NewLine, captured.Infos);
+
+            allOutput.Should().Contain(expected);
+        }
+
+        public void AssertOutputMatches(string regex, string message = null)
+        {
+            var allOutput = string.Join(Environment.NewLine, captured.Infos);
+
+            Assert.That(allOutput, Does.Match(regex), message);
+        }
+
+        public void AssertNoOutputMatches(string regex)
+        {
+            var allOutput = string.Join(Environment.NewLine, captured.Infos);
+
+            Assert.That(allOutput, Does.Not.Match(regex));
+        }
+
+        public string GetOutputForLineContaining(string expectedOutput)
+        {
+            var found = captured.Infos.SingleOrDefault(i => i.ContainsIgnoreCase(expectedOutput));
+            found.Should().NotBeNull($"'{expectedOutput}' should exist");
+            return found;
+        }
+
+        public void AssertErrorOutput(string expectedOutputFormat, params object[] args)
+        {
+            AssertErrorOutput(String.Format(expectedOutputFormat, args));
+        }
+
+        public void AssertErrorOutput(string expectedOutput, bool noNewLines = false)
+        {
+            var separator = noNewLines ? String.Empty : Environment.NewLine;
+            var allOutput = string.Join(separator, captured.Errors);
+            Assert.That(allOutput, Does.Contain(expectedOutput));
+        }
+
+        //Assuming we print properties like:
+        //"name: expectedValue"
+        public void AssertPropertyValue(string name, params string[] expectedValues)
+        {
+            var title = name + ":";
+            string line = GetOutputForLineContaining(title);
+
+            line.Replace(title, "").Should().BeOneOf(expectedValues);
+        }
+
+        public void AssertProcessNameAndId(string processName)
+        {
+            AssertOutputMatches(@"HostProcess: (Calamari|dotnet|mono-sgen32|mono-sgen64|mono-sgen) \([0-9]+\)", "Calamari process name and id are printed");
+            AssertOutputMatches($@"HostProcess: ({processName}|mono-sgen32|mono-sgen64|mono-sgen) \([0-9]+\)", $"{processName} process name and id are printed");
+        }
+    }
+}

--- a/source/Calamari.Tests.Shared/Helpers/CaptureCommandInvocationOutputSink.cs
+++ b/source/Calamari.Tests.Shared/Helpers/CaptureCommandInvocationOutputSink.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using Calamari.Integration.Processes;
+using Calamari.Integration.ServiceMessages;
+using Calamari.Tests.Shared.LogParser;
+using Calamari.Variables;
+using Octostache;
+using ServiceMessageParser = Calamari.Integration.ServiceMessages.ServiceMessageParser;
+
+namespace Calamari.Tests.Helpers
+{
+    //Ideally sourced directly from Octopus.Worker repo
+    public class CaptureCommandInvocationOutputSink : ICommandInvocationOutputSink
+    {
+        readonly List<string> all = new List<string>();
+        readonly List<string> infos = new List<string>();
+        readonly List<string> errors = new List<string>();
+        readonly ServiceMessageParser serviceMessageParser;
+        readonly IVariables outputVariables = new CalamariVariables();
+
+        public CaptureCommandInvocationOutputSink()
+        {
+            serviceMessageParser = new ServiceMessageParser(ParseServiceMessage);
+        }
+
+        public void WriteInfo(string line)
+        {
+            serviceMessageParser.Parse(line);
+            all.Add(line);
+            infos.Add(line);
+        }
+
+        public void WriteError(string line)
+        {
+            all.Add(line);
+            errors.Add(line);
+        }
+
+        public IVariables OutputVariables => outputVariables;
+
+        public IList<string> Infos => infos;
+
+        public IList<string> Errors => errors;
+
+        public IList<string> AllMessages => all;
+
+        public bool CalamariFoundPackage { get; protected set; }
+
+        public FoundPackage FoundPackage { get; protected set; }
+
+        public DeltaPackage DeltaVerification { get; protected set; }
+
+        public string DeltaError { get; protected set; }
+
+        void ParseServiceMessage(ServiceMessage message)
+        {
+            switch (message.Name)
+            {
+                case ServiceMessageNames.SetVariable.Name:
+                    var variableName = message.GetValue(ServiceMessageNames.SetVariable.NameAttribute);
+                    var variableValue = message.GetValue(ServiceMessageNames.SetVariable.ValueAttribute);
+
+                    if (!string.IsNullOrWhiteSpace(variableName))
+                        outputVariables.Set(variableName, variableValue);
+                    break;
+                case ServiceMessageNames.CalamariFoundPackage.Name:
+                    CalamariFoundPackage = true;
+                    break;
+                case ServiceMessageNames.FoundPackage.Name:
+                    var foundPackageId = message.GetValue(ServiceMessageNames.FoundPackage.IdAttribute);
+                    var foundPackageVersion = message.GetValue(ServiceMessageNames.FoundPackage.VersionAttribute);
+                    var foundPackageVersionFormat = message.GetValue(ServiceMessageNames.FoundPackage.VersionFormat );
+                    var foundPackageHash = message.GetValue(ServiceMessageNames.FoundPackage.HashAttribute);
+                    var foundPackageRemotePath = message.GetValue(ServiceMessageNames.FoundPackage.RemotePathAttribute);
+                    var fileExtension = message.GetValue(ServiceMessageNames.FoundPackage.FileExtensionAttribute);
+                    FoundPackage = new FoundPackage(foundPackageId, foundPackageVersion, foundPackageVersionFormat, foundPackageRemotePath,
+                        foundPackageHash, fileExtension);
+                    break;
+                case ServiceMessageNames.PackageDeltaVerification.Name:
+                    var pdvHash = message.GetValue(ServiceMessageNames.PackageDeltaVerification.HashAttribute);
+                    var pdvSize = message.GetValue(ServiceMessageNames.PackageDeltaVerification.SizeAttribute);
+                    var pdvRemotePath =
+                        message.GetValue(ServiceMessageNames.PackageDeltaVerification.RemotePathAttribute);
+                    DeltaError = message.GetValue(ServiceMessageNames.PackageDeltaVerification.Error);
+                    if (pdvHash != null)
+                    {
+                        DeltaVerification = new DeltaPackage(pdvRemotePath, pdvHash, long.Parse(pdvSize));
+                    }
+
+                    break;
+            }
+        }
+    }
+}

--- a/source/Calamari.Tests.Shared/Helpers/TestCommandLineRunner.cs
+++ b/source/Calamari.Tests.Shared/Helpers/TestCommandLineRunner.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using Calamari.Integration.Processes;
+using Calamari.Integration.ServiceMessages;
+
+namespace Calamari.Tests.Helpers
+{
+    public class TestCommandLineRunner : CommandLineRunner
+    {
+        readonly IVariables variables;
+
+        public TestCommandLineRunner(ILog log, IVariables variables) : base(log, variables)
+        {
+            this.variables = variables;
+            Output = new CaptureCommandInvocationOutputSink();
+        }
+
+        public CaptureCommandInvocationOutputSink Output { get; }
+
+        protected override List<ICommandInvocationOutputSink> GetCommandOutputs(CommandLineInvocation invocation)
+            => new List<ICommandInvocationOutputSink>()
+            {
+                Output,
+                new ServiceMessageCommandInvocationOutputSink(variables)
+            };
+    }
+}

--- a/source/Sashimi.Aws.Tests/CloudFormation/CloudFormationActionHandlerFixture.cs
+++ b/source/Sashimi.Aws.Tests/CloudFormation/CloudFormationActionHandlerFixture.cs
@@ -45,9 +45,8 @@ namespace Sashimi.Aws.Tests.CloudFormation
 
                         context.Variables.Add(AwsSpecialVariables.Action.Aws.WaitForCompletion, bool.TrueString);
                     })
-                    .Execute(false);
+                    .Execute();
 
-            result.WasSuccessful.Should().BeTrue();
             result.OutputVariables["AwsOutputs[OutputName]"].Value.Should().Be(bucketName);
         }
 
@@ -74,9 +73,7 @@ namespace Sashimi.Aws.Tests.CloudFormation
                     context.Variables.Add(AwsSpecialVariables.Action.Aws.WaitForCompletion, bool.TrueString);
                     context.Variables.Add("NameVarParamValue", nameVarParamValue);
                 })
-                .Execute(false);
-
-            result.WasSuccessful.Should().BeTrue();
+                .Execute();
 
             result.OutputVariables["AwsOutputs[OutputWithVariableParam]"].Value.Should().Be(nameVarParamValue);
             result.OutputVariables["AwsOutputs[OutputWithPlainParam]"].Value.Should().Be(namePlainParamValue);
@@ -112,9 +109,8 @@ namespace Sashimi.Aws.Tests.CloudFormation
 
                     context.Variables.Add(AwsSpecialVariables.Action.Aws.WaitForCompletion, bool.TrueString);
                 })
-                .Execute(false);
+                .Execute();
 
-            result.WasSuccessful.Should().BeTrue();
             result.OutputVariables["AwsOutputs[OutputName]"].Value.Should().Be(bucketName);
 
             Directory.Delete(tempFolderPath, true);
@@ -155,7 +151,7 @@ namespace Sashimi.Aws.Tests.CloudFormation
                     context.Variables.Add("NameVarParamValue", nameVarParamValue);
                     context.Variables.Add(AwsSpecialVariables.Action.Aws.WaitForCompletion, bool.TrueString);
                 })
-                .Execute(false);
+                .Execute();
 
             result.OutputVariables["AwsOutputs[OutputWithVariableParam]"].Value.Should().Be(nameVarParamValue);
             result.OutputVariables["AwsOutputs[OutputWithPlainParam]"].Value.Should().Be(namePlainParamValue);

--- a/source/Sashimi.Aws.Tests/CloudFormation/CloudFormationActionHandlerFixture.cs
+++ b/source/Sashimi.Aws.Tests/CloudFormation/CloudFormationActionHandlerFixture.cs
@@ -13,7 +13,7 @@ namespace Sashimi.Aws.Tests.CloudFormation
     public class CloudFormationActionHandlerFixture
     {
         const string AwsStackRole = "arn:aws:iam::968802670493:role/e2e_buckets";
-        // BucketName must use the following prefix, otherwise the above stack role will not have permission to access 
+        // BucketName must use the following prefix, otherwise the above stack role will not have permission to access
         const string ValidBucketNamePrefix = "cfe2e-";
         const string StackNamePrefix = "E2ETestStack-";
         const string TransformIncludeLocation = "s3://octopus-e2e-tests/permanent/tags.json";
@@ -42,7 +42,7 @@ namespace Sashimi.Aws.Tests.CloudFormation
                             .WithAwsRegion(AwsRegion)
                             .WithStackRole(AwsStackRole)
                             .WithAwsTemplateInlineSource(template, null);
-                        
+
                         context.Variables.Add(AwsSpecialVariables.Action.Aws.WaitForCompletion, bool.TrueString);
                     })
                     .Execute(false);
@@ -98,7 +98,7 @@ namespace Sashimi.Aws.Tests.CloudFormation
 
             var packageFileName = CreateNugetPackage($"{nameof(RunCloudFormation_PackageWithoutParameters)}", tempFolderPath);
             var pathToPackage = Path.Combine(tempFolderPath, packageFileName);
-            
+
             var result = ActionHandlerTestBuilder.Create<AwsRunCloudFormationActionHandler, Calamari.Aws.Program>()
                 .WithArrange(context =>
                 {
@@ -160,12 +160,12 @@ namespace Sashimi.Aws.Tests.CloudFormation
 
             Directory.Delete(tempFolderPath, true);
         }
-        
+
         [Test]
         public void RunCloudFormation_ChangeSet()
         {
             var bucketName = $"{ValidBucketNamePrefix}{UniqueName.Generate()}";
-            var pathToPackage = TestEnvironment.GetTestPath(@"Packages\CloudFormationS3.1.0.0.nupkg");
+            var pathToPackage = TestEnvironment.GetTestPath(@"Packages/CloudFormationS3.1.0.0.nupkg");
 
             // create bucket
             CreateBucket(stackName, bucketName, pathToPackage);
@@ -252,13 +252,13 @@ namespace Sashimi.Aws.Tests.CloudFormation
                         .WithAwsTemplatePackageSource("bucket.json", "bucket-parameters.json")
                         .WithCloudFormationChangeSets(deferExecution: true)
                         .WithIamCapabilities(new List<string> { "CAPABILITY_IAM"});
-                            
+
                     context.Variables.Add("BucketName", bucketName);
                     context.Variables.Add("TransformIncludeLocation", TransformIncludeLocation);
                     context.Variables.Add(AwsSpecialVariables.Action.Aws.WaitForCompletion, bool.TrueString);
                 })
                 .Execute();
-            
+
             return (result.OutputVariables["AwsOutputs[ChangesetId]"].Value, result.OutputVariables["AwsOutputs[StackId]"].Value);
         }
 

--- a/source/Sashimi.Aws.Tests/RunScript/AwsS3UploadActionHandlerFixture.cs
+++ b/source/Sashimi.Aws.Tests/RunScript/AwsS3UploadActionHandlerFixture.cs
@@ -24,7 +24,7 @@ namespace Sashimi.Aws.Tests.RunScript
             var bucketName = "octopus-e2e-tests";
             var region = "ap-southeast-1";
             var folderPrefix = $"test/{Guid.NewGuid()}/";
-            var path = TestEnvironment.GetTestPath(@"AwsS3Sample\AwsS3Sample.1.0.0.nupkg");
+            var path = TestEnvironment.GetTestPath(@"AwsS3Sample/AwsS3Sample.1.0.0.nupkg");
 
             ActionHandlerTestBuilder.Create<AwsUploadS3ActionHandler, Program>()
                 .WithArrange(context =>
@@ -61,7 +61,7 @@ namespace Sashimi.Aws.Tests.RunScript
             var bucketName = "octopus-e2e-tests";
             var region = "ap-southeast-1";
             var folderPrefix = $"test/{Guid.NewGuid().ToString()}/";
-            var path = TestEnvironment.GetTestPath(@"AwsS3Sample\AwsS3Sample.1.0.0.nupkg");
+            var path = TestEnvironment.GetTestPath(@"AwsS3Sample/AwsS3Sample.1.0.0.nupkg");
 
             ActionHandlerTestBuilder.Create<AwsUploadS3ActionHandler, Program>()
                 .WithArrange(context =>

--- a/source/Sashimi.Aws.Tests/RunScript/AwsS3UploadActionHandlerFixture.cs
+++ b/source/Sashimi.Aws.Tests/RunScript/AwsS3UploadActionHandlerFixture.cs
@@ -37,7 +37,7 @@ namespace Sashimi.Aws.Tests.RunScript
                     context.Variables.Add(AwsSpecialVariables.Action.Aws.S3.BucketName, bucketName);
                     context.Variables.Add(AwsSpecialVariables.Action.Aws.S3.TargetMode, "EntirePackage");
                     context.WithAwsAccount();
-                    context.WithPackage(path);
+                    context.WithPackage(("AwsS3Sample", path));
                     context.Variables.Add(
                         AwsSpecialVariables.Action.Aws.S3.PackageOptions,
                         JsonConvert.SerializeObject(new S3PackageProperties
@@ -73,7 +73,7 @@ namespace Sashimi.Aws.Tests.RunScript
                     context.Variables.Add(SpecialVariables.Action.Aws.UseInstanceRole, bool.FalseString);
                     context.Variables.Add(AwsSpecialVariables.Action.Aws.S3.BucketName, bucketName);
                     context.Variables.Add(AwsSpecialVariables.Action.Aws.S3.TargetMode, S3TargetMode.FileSelections.ToString());
-                    context.WithPackage(path);
+                    context.WithPackage(("AwsS3Sample", path));
                     context.WithAwsAccount();
                     context.Variables.Add(
                         AwsSpecialVariables.Action.Aws.S3.FileSelections,

--- a/source/Sashimi.Tests.Shared/Server/ActionHandlerTestBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/ActionHandlerTestBuilder.cs
@@ -12,14 +12,14 @@ namespace Sashimi.Tests.Shared.Server
 {
     public static class ActionHandlerTestBuilder
     {
-        public static ActionHandlerTestBuilder<TCalamari> Create<TActionHandler, TCalamari>() 
+        public static ActionHandlerTestBuilder<TCalamari> Create<TActionHandler, TCalamari>()
             where TActionHandler : IActionHandler
             where TCalamari : CalamariFlavourProgram
         {
             return new ActionHandlerTestBuilder<TCalamari>(typeof(TActionHandler));
         }
-        
-        public static ActionHandlerTestBuilder<TCalamari> Create<TCalamari>(Type actionHandlerType) 
+
+        public static ActionHandlerTestBuilder<TCalamari> Create<TCalamari>(Type actionHandlerType)
             where TCalamari : CalamariFlavourProgram
         {
             return new ActionHandlerTestBuilder<TCalamari>(actionHandlerType);
@@ -35,8 +35,8 @@ namespace Sashimi.Tests.Shared.Server
             return context;
         }
     }
-    
-    public class ActionHandlerTestBuilder<TCalamariProgram> 
+
+    public class ActionHandlerTestBuilder<TCalamariProgram>
         where TCalamariProgram : CalamariFlavourProgram
     {
         readonly List<Action<TestActionHandlerContext<TCalamariProgram>>> arrangeActions;
@@ -71,7 +71,7 @@ namespace Sashimi.Tests.Shared.Server
 
             foreach (var arrangeAction in arrangeActions)
             {
-                arrangeAction?.Invoke(context);    
+                arrangeAction?.Invoke(context);
             }
 
             TestActionHandlerResult result;
@@ -84,7 +84,7 @@ namespace Sashimi.Tests.Shared.Server
 
             if (assertWasSuccess)
             {
-                result.WasSuccessful.Should().BeTrue($"{actionHandlerType} execute result was unsuccessful");
+                result.WasSuccessful.Should().BeTrue($"{actionHandlerType} execute result was unsuccessful: " + result.FullLog);
             }
             assertAction?.Invoke(result);
 

--- a/source/Sashimi.Tests.Shared/Server/ActionHandlerTestBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/ActionHandlerTestBuilder.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using System.IO;
 using Autofac;
 using Calamari.Common;
+using Calamari.Common.Plumbing.Variables;
 using FluentAssertions;
 using Octopus.Diagnostics;
-using Sashimi.Server.Contracts;
 using Sashimi.Server.Contracts.ActionHandlers;
+using KnownVariables = Sashimi.Server.Contracts.KnownVariables;
 
 namespace Sashimi.Tests.Shared.Server
 {
@@ -25,11 +26,11 @@ namespace Sashimi.Tests.Shared.Server
             return new ActionHandlerTestBuilder<TCalamari>(actionHandlerType);
         }
 
-        public static TestActionHandlerContext<TCalamariProgram> WithPackage<TCalamariProgram>(this TestActionHandlerContext<TCalamariProgram> context, string path)
+        public static TestActionHandlerContext<TCalamariProgram> WithPackage<TCalamariProgram>(this TestActionHandlerContext<TCalamariProgram> context, (string Id, string Path) package)
             where TCalamariProgram : CalamariFlavourProgram
         {
-            context.Variables.Add(KnownVariables.OriginalPackageDirectoryPath, Path.GetDirectoryName(path));
-            context.Variables.Add(KnownVariables.Action.Packages.PackageId, path);
+            context.Variables.Add(TentacleVariables.CurrentDeployment.PackageFilePath, package.Path);
+            context.Variables.Add(KnownVariables.Action.Packages.PackageId, package.Id);
             context.Variables.Add(KnownVariables.Action.Packages.FeedId, "FeedId");
 
             return context;

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -255,13 +255,12 @@ namespace Sashimi.Tests.Shared.Server
 
         IActionHandlerResult ExecuteActionHandlerOutProc(List<string> args)
         {
-            Console.WriteLine("Running Calamari OutProc");
             using (var variablesFile = new TemporaryFile(Path.GetTempFileName()))
             {
                 variables.Save(variablesFile.FilePath);
 
                 var calamariFullPath = GetOutProcCalamariExePath();
-                Console.WriteLine("Running Calamari from: "+ calamariFullPath);
+                Console.WriteLine("Running Calamari OutProc from: "+ calamariFullPath);
 
                 MakeExecutable(calamariFullPath);
 
@@ -331,7 +330,7 @@ namespace Sashimi.Tests.Shared.Server
             var calamariProjectFolder = Path.GetFullPath(Path.Combine(sashimiTestFolder, "../../../..", calamariFlavour));
             DotNetPublish(calamariProjectFolder, configuration, targetFramework, runtime);
 
-            return AddExeIfNecessary(Path.Combine(calamariProjectFolder, "bin", "Debug", targetFramework, runtime, "publish", calamariFlavour));
+            return AddExeIfNecessary(Path.Combine(calamariProjectFolder, "bin", configuration, targetFramework, runtime, "publish", calamariFlavour));
 
             void DotNetPublish(string calamariProjectFolder, string configuration, string targetFramework, string runtime)
             {

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -255,8 +255,7 @@ namespace Sashimi.Tests.Shared.Server
                 var calamariFullPath = GetOutProcCalamariExePath();
                 Console.WriteLine("Running Calamari from: "+ calamariFullPath);
 
-                var commandLine = new CommandLine("/usr/bin/mono");
-                commandLine.Argument(calamariFullPath);
+                var commandLine = new CommandLine(calamariFullPath);
                 foreach (var argument in args)
                     commandLine = commandLine.Argument(argument);
 

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -278,7 +278,7 @@ namespace Sashimi.Tests.Shared.Server
 
             if (TestEnvironment.IsCI)
             {
-                var calamariFullPath = Path.GetFullPath(Path.Combine("..", "CalamariBinaries", calamariExe));
+                var calamariFullPath = Path.GetFullPath(Path.Combine(Environment.GetEnvironmentVariable("env.checkoutdir"), "CalamariBinaries", calamariExe));
                 Console.WriteLine("Running Calamari from: "+ calamariFullPath);
                 return new CommandLine(calamariFullPath);
             }

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -24,13 +24,13 @@ namespace Sashimi.Tests.Shared.Server
 {
     class TestCalamariCommandBuilder<TCalamariProgram> : ICalamariCommandBuilder where TCalamariProgram : CalamariFlavourProgram
     {
-        const string CalamaribinariesLocationEnvironmentVariable = "CalamariBinaries";
+        const string CalamaribinariesLocationEnvironmentVariable = "CalamariBinaries_RelativePath";
 
         static class InProcOutProcOverride
         {
-            public static readonly string EnvironmentVariable = "inproc_outproc_override";
-            public static readonly string InProcValue = "inproc";
-            public static readonly string OutProcValue = "outproc";
+            public static readonly string EnvironmentVariable = "Test_Calamari_InProc_OutProc_Override";
+            public static readonly string InProcValue = "InProc";
+            public static readonly string OutProcValue = "OutProc";
         }
 
         public TestCalamariCommandBuilder(CalamariFlavour calamariFlavour, string calamariCommand)

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -24,6 +24,15 @@ namespace Sashimi.Tests.Shared.Server
 {
     class TestCalamariCommandBuilder<TCalamariProgram> : ICalamariCommandBuilder where TCalamariProgram : CalamariFlavourProgram
     {
+        const string CalamaribinariesLocationEnvironmentVariable = "CalamariBinaries";
+
+        static class InProcOutProcOverride
+        {
+            public static readonly string EnvironmentVariable = "inproc_outproc_override";
+            public static readonly string InProcValue = "inproc";
+            public static readonly string OutProcValue = "outproc";
+        }
+
         public TestCalamariCommandBuilder(CalamariFlavour calamariFlavour, string calamariCommand)
         {
             CalamariFlavour = calamariFlavour;
@@ -176,20 +185,16 @@ namespace Sashimi.Tests.Shared.Server
 
         IActionHandlerResult ExecuteActionHandler(List<string> args)
         {
-            const string inProcOutProcOverrideEnvironmentVariableName = "inproc_outproc_override";
-            const string inProc = "inproc";
-            const string outroc = "outproc";
-
-            var inProcOutProcOverride = Environment.GetEnvironmentVariable(inProcOutProcOverrideEnvironmentVariableName);
+            var inProcOutProcOverride = Environment.GetEnvironmentVariable(InProcOutProcOverride.EnvironmentVariable);
             if (!string.IsNullOrEmpty(inProcOutProcOverride))
             {
-                if (inProc.Equals(inProcOutProcOverride, StringComparison.OrdinalIgnoreCase))
+                if (InProcOutProcOverride.InProcValue.Equals(inProcOutProcOverride, StringComparison.OrdinalIgnoreCase))
                     return ExecuteActionHandlerInProc(args);
 
-                if (outroc.Equals(inProcOutProcOverride, StringComparison.OrdinalIgnoreCase))
+                if (InProcOutProcOverride.OutProcValue.Equals(inProcOutProcOverride, StringComparison.OrdinalIgnoreCase))
                     return ExecuteActionHandlerOutProc(args);
 
-                throw new Exception($"'{inProcOutProcOverrideEnvironmentVariableName}' environment variable must be '{inProc}' or '{outroc}'");
+                throw new Exception($"'{InProcOutProcOverride.EnvironmentVariable}' environment variable must be '{InProcOutProcOverride.InProcValue}' or '{InProcOutProcOverride.OutProcValue}'");
             }
 
             if (TestEnvironment.IsCI)
@@ -291,7 +296,7 @@ namespace Sashimi.Tests.Shared.Server
             if (TestEnvironment.IsCI)
             {
                 //This is where Teamcity puts the Calamari binaries
-                var calamaribinariesFolder = Environment.GetEnvironmentVariable("CalamariBinaries");
+                var calamaribinariesFolder = Environment.GetEnvironmentVariable(CalamaribinariesLocationEnvironmentVariable);
                 return AddExeIfNecessary(Path.GetFullPath(Path.Combine(sashimiTestFolder, calamaribinariesFolder, calamariFlavour)));
             }
 

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -260,6 +260,8 @@ namespace Sashimi.Tests.Shared.Server
                 var calamariFullPath = GetOutProcCalamariExePath();
                 Console.WriteLine("Running Calamari from: "+ calamariFullPath);
 
+                MakeExecutable(calamariFullPath);
+
                 var commandLine = new CommandLine(calamariFullPath);
                 foreach (var argument in args)
                     commandLine = commandLine.Argument(argument);
@@ -286,6 +288,23 @@ namespace Sashimi.Tests.Shared.Server
                     outputFilter.ServiceMessages, outputFilter.ResultMessage, outputFilter.Artifacts,
                     serverInMemoryLog.ToString());
             }
+        }
+
+        static void MakeExecutable(string calamariFullPath)
+        {
+            if (!CalamariEnvironment.IsRunningOnNix)
+                return;
+
+            var stdOut = new StringBuilder();
+            var stdError = new StringBuilder();
+            var result = SilentProcessRunner.ExecuteCommand("chmod",
+                $"+x {calamariFullPath}",
+                Path.GetDirectoryName(calamariFullPath),
+                s => stdOut.AppendLine(s),
+                s => stdError.AppendLine(s));
+
+            if (result.ExitCode != 0)
+                throw new Exception(stdOut.ToString() + stdError);
         }
 
         string GetOutProcCalamariExePath()

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -279,9 +279,13 @@ namespace Sashimi.Tests.Shared.Server
             var calamariFullPathInSashimiTestFolder = typeof(TCalamariProgram).Assembly.FullLocalPath();
             var calamariExe = Path.GetFileNameWithoutExtension(calamariFullPathInSashimiTestFolder);
 
+            Console.WriteLine("calamariFullPathInSashimiTestFolder directory: "+ GetType().Assembly.FullLocalPath());
+            var fullPath = Path.GetFullPath(Path.Combine(calamariFullPathInSashimiTestFolder, "..", "CalamariBinaries", calamariExe));
+            Console.WriteLine("pretend directory: "+ fullPath);
+
             if (TestEnvironment.IsCI)
             {
-                var calamariFullPath = Path.GetFullPath(Path.Combine(Environment.GetEnvironmentVariable("env.checkoutdir"), "CalamariBinaries", calamariExe));
+                var calamariFullPath = fullPath;//Path.GetFullPath(Path.Combine(Environment.GetEnvironmentVariable("env.checkoutdir"), "CalamariBinaries", calamariExe));
                 Console.WriteLine("Running Calamari from: "+ calamariFullPath);
                 return new CommandLine(calamariFullPath);
             }

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -290,9 +290,9 @@ namespace Sashimi.Tests.Shared.Server
 
             if (TestEnvironment.IsCI)
             {
-                //This is where Teamcity puts the Calamari binaries, extract to environment variable?
-                var calamaribinariesFolder = "CalamariBinaries";
-                return AddExeIfNecessary(Path.GetFullPath(Path.Combine(sashimiTestFolder, "..", calamaribinariesFolder, calamariFlavour)));
+                //This is where Teamcity puts the Calamari binaries
+                var calamaribinariesFolder = Environment.GetEnvironmentVariable("CalamariBinaries");
+                return AddExeIfNecessary(Path.GetFullPath(Path.Combine(sashimiTestFolder, calamaribinariesFolder, calamariFlavour)));
             }
 
             //Running locally - change these to your liking

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -280,7 +280,7 @@ namespace Sashimi.Tests.Shared.Server
             var calamariExe = Path.GetFileNameWithoutExtension(calamariFullPathInSashimiTestFolder);
 
             Console.WriteLine("calamariFullPathInSashimiTestFolder directory: "+ GetType().Assembly.FullLocalPath());
-            var fullPath = Path.GetFullPath(Path.Combine(calamariFullPathInSashimiTestFolder, "..", "CalamariBinaries", calamariExe));
+            var fullPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(calamariFullPathInSashimiTestFolder), "..", "CalamariBinaries", calamariExe));
             Console.WriteLine("pretend directory: "+ fullPath);
 
             if (TestEnvironment.IsCI)

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -173,7 +173,7 @@ namespace Sashimi.Tests.Shared.Server
 
             if (withStagedPackageArgument)
             {
-                var packageId = variables.GetRaw(KnownVariables.Action.Packages.PackageId);
+                var packageId = variables.GetRaw(TentacleVariables.CurrentDeployment.PackageFilePath);
                 if (File.Exists(packageId))
                 {
                     var fileName = new FileInfo(packageId).Name;

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -295,7 +295,7 @@ namespace Sashimi.Tests.Shared.Server
 
         static void MakeExecutable(string calamariFullPath)
         {
-            if (!CalamariEnvironment.IsRunningOnNix)
+            if (CalamariEnvironment.IsRunningOnWindows)
                 return;
 
             var stdOut = new StringBuilder();

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -273,6 +273,9 @@ namespace Sashimi.Tests.Shared.Server
         //Need to build and load correct version of Calamari and TC
         CommandLine Calamari()
         {
+            Console.WriteLine("Current directory: "+ Environment.CurrentDirectory);
+            Console.WriteLine("DLL directory: "+ GetType().Assembly.FullLocalPath());
+
             var calamariFullPathInSashimiTestFolder = typeof(TCalamariProgram).Assembly.FullLocalPath();
             var calamariExe = Path.GetFileNameWithoutExtension(calamariFullPathInSashimiTestFolder);
 

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -290,8 +290,9 @@ namespace Sashimi.Tests.Shared.Server
 
             if (TestEnvironment.IsCI)
             {
-                var calamaribinariesFolder = "CalamariBinaries"; //This is where Teamcity puts the Calamari binaries, extract to environment variable?
-                return Path.GetFullPath(Path.Combine(sashimiTestFolder, "..", calamaribinariesFolder, calamariFlavour));
+                //This is where Teamcity puts the Calamari binaries, extract to environment variable?
+                var calamaribinariesFolder = "CalamariBinaries";
+                return AddExeIfNecessary(Path.GetFullPath(Path.Combine(sashimiTestFolder, "..", calamaribinariesFolder, calamariFlavour)));
             }
 
             //Running locally - change these to your liking
@@ -303,7 +304,7 @@ namespace Sashimi.Tests.Shared.Server
             var calamariProjectFolder = Path.GetFullPath(Path.Combine(sashimiTestFolder, "../../../..", calamariFlavour));
             DotNetPublish(calamariProjectFolder, configuration, targetFramework, runtime);
 
-            return Path.Combine(calamariProjectFolder, "bin", "Debug", targetFramework, runtime, "publish", calamariFlavour);
+            return AddExeIfNecessary(Path.Combine(calamariProjectFolder, "bin", "Debug", targetFramework, runtime, "publish", calamariFlavour));
 
             void DotNetPublish(string calamariProjectFolder, string configuration, string targetFramework, string runtime)
             {
@@ -317,6 +318,18 @@ namespace Sashimi.Tests.Shared.Server
 
                 if (result.ExitCode != 0)
                     throw new Exception(stdOut.ToString() + stdError);
+            }
+
+            string AddExeIfNecessary(string exePath)
+            {
+                if (File.Exists(exePath))
+                    return exePath;
+
+                var withExeExtension = exePath + ".exe";
+                if (File.Exists(withExeExtension))
+                    return withExeExtension;
+
+                throw new Exception($"Calamari exe doesn't exist on disk: '{exePath}'");
             }
         }
 

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -255,7 +255,8 @@ namespace Sashimi.Tests.Shared.Server
                 var calamariFullPath = GetOutProcCalamariExePath();
                 Console.WriteLine("Running Calamari from: "+ calamariFullPath);
 
-                var commandLine = new CommandLine(calamariFullPath);
+                var commandLine = new CommandLine("/usr/bin/mono");
+                commandLine.Argument(calamariFullPath);
                 foreach (var argument in args)
                     commandLine = commandLine.Argument(argument);
 

--- a/source/Sashimi.Tests.Shared/TestEnvironment.cs
+++ b/source/Sashimi.Tests.Shared/TestEnvironment.cs
@@ -1,12 +1,14 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Calamari;
 
 namespace Sashimi.Tests.Shared
 {
-    public static class TestEnvironment 
+    public static class TestEnvironment
     {
         public static readonly string AssemblyLocalPath = typeof(TestEnvironment).Assembly.FullLocalPath();
         public static readonly string CurrentWorkingDirectory = Path.GetDirectoryName(AssemblyLocalPath);
+        public static readonly bool IsCI = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TEAMCITY_VERSION"));
 
         public static string GetTestPath(params string[] paths)
         {


### PR DESCRIPTION
We're changing the Sashimi builds (currently just 1 cake file with build+test) and splitting it up so we can run tests on multiple platforms like [Calamari ](https://build.octopushq.com/project.html?projectId=OctopusDeploy_CalamariNetCore) does.

The new build tree is [here](https://build.octopushq.com/project.html?projectId=OctopusDeploy_LIbraries_Sashimi).