### PR TITLE
Support the new Calamari-like build pipeline

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -134,7 +134,7 @@ Task("PublishCalamariProjects")
 });
 
 Task("PublishSashimiTestProjects")
-   .IsDependentOn("Build")
+    .IsDependentOn("Build")
     .Does(() => {
         var projects = GetFiles("./source/**/Sashimi.*.Tests.csproj");
 		foreach(var project in projects)

--- a/build.cake
+++ b/build.cake
@@ -133,7 +133,31 @@ Task("PublishCalamariProjects")
         }
 });
 
+Task("PublishSashimiTestProjects")
+   .IsDependentOn("Build")
+    .Does(() => {
+        var projects = GetFiles("./source/**/Sashimi.*Tests*.csproj");
+		foreach(var project in projects)
+        {
+            var sashimiFlavour = project.GetFilenameWithoutExtension().ToString();
+
+                void RunPublish() {
+                     DotNetCorePublish(project.FullPath, new DotNetCorePublishSettings
+		    	    {
+		    	    	Configuration = configuration,
+                        OutputDirectory = $"{publishDir}/{sashimiFlavour}"
+		    	    });
+                }
+
+                RunPublish();
+
+            Console.WriteLine($"{publishDir}/{sashimiFlavour}");
+            Zip($"{publishDir}{sashimiFlavour}", $"{artifactsDir}{sashimiFlavour}.zip");
+        }
+});
+
 Task("PackSashimi")
+    .IsDependentOn("PublishSashimiTestProjects")
     .IsDependentOn("PublishCalamariProjects")
     .Does(() =>
 {

--- a/build.cake
+++ b/build.cake
@@ -136,7 +136,7 @@ Task("PublishCalamariProjects")
 Task("PublishSashimiTestProjects")
    .IsDependentOn("Build")
     .Does(() => {
-        var projects = GetFiles("./source/**/Sashimi.*Tests*.csproj");
+        var projects = GetFiles("./source/**/Sashimi.*.Tests.csproj");
 		foreach(var project in projects)
         {
             var sashimiFlavour = project.GetFilenameWithoutExtension().ToString();

--- a/source/Calamari.Tests.Shared/Helpers/CalamariResult.cs
+++ b/source/Calamari.Tests.Shared/Helpers/CalamariResult.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Calamari.Common.Plumbing.Extensions;
+using Calamari.Common.Plumbing.ServiceMessages;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+
+namespace Calamari.Tests.Helpers
+{
+    public class CalamariResult
+    {
+        private readonly int exitCode;
+        private readonly CaptureCommandInvocationOutputSink captured;
+
+        public CalamariResult(int exitCode, CaptureCommandInvocationOutputSink captured)
+        {
+            this.exitCode = exitCode;
+            this.captured = captured;
+        }
+
+        public int ExitCode
+        {
+            get { return exitCode; }
+        }
+
+        public CaptureCommandInvocationOutputSink CapturedOutput
+        {
+            get { return captured; }
+        }
+
+        public void AssertSuccess()
+        {
+            var capturedErrors = string.Join(Environment.NewLine, captured.Errors);
+            Assert.That(ExitCode, Is.EqualTo(0), string.Format("Expected command to return exit code 0, instead returned {2}{0}{0}Output:{0}{1}", Environment.NewLine, capturedErrors, ExitCode));
+        }
+
+        public void AssertFailure()
+        {
+            Assert.That(ExitCode, Is.Not.EqualTo(0), "Expected a non-zero exit code");
+        }
+
+
+        public void AssertFailure(int code)
+        {
+            Assert.That(ExitCode, Is.EqualTo(code), $"Expected an exit code of {code}");
+        }
+
+        public void AssertOutput(string expectedOutputFormat, params object[] args)
+        {
+            AssertOutput(String.Format(expectedOutputFormat, args));
+        }
+
+        public void AssertOutputVariable(string name, IResolveConstraint resolveConstraint)
+        {
+            var variable = captured.OutputVariables.Get(name);
+            Assert.That(variable, resolveConstraint);
+        }
+
+        public void AssertServiceMessage(string name, IResolveConstraint resolveConstraint = null, Dictionary<string, object> properties = null, string message = "", params object[] args)
+        {
+            switch (name)
+            {
+                case ServiceMessageNames.CalamariFoundPackage.Name:
+                    Assert.That(captured.CalamariFoundPackage, resolveConstraint, message, args);
+                    break;
+                case ServiceMessageNames.FoundPackage.Name:
+                    Assert.That(captured.FoundPackage, Is.Not.Null);
+                    if (properties != null)
+                    {
+                        Assert.That(resolveConstraint, Is.Not.Null, "Resolve constraint was not provided");
+                        foreach (var property in properties)
+                        {
+                            var fp = JObject.FromObject(captured.FoundPackage);
+                            string value;
+                            if (property.Key.Contains("."))
+                            {
+                                var props = property.Key.Split(new[] {'.'}, StringSplitOptions.RemoveEmptyEntries);
+                                value = fp[props[0]][props[1]].ToString();
+                            }
+                            else
+                            {
+                                value = fp[property.Key].ToString();
+                            }
+
+                            AssertServiceMessageValue(property.Key, property.Value, value, resolveConstraint);
+                        }
+                    }
+
+                    break;
+                case ServiceMessageNames.PackageDeltaVerification.Name:
+                    if (!string.IsNullOrWhiteSpace(message))
+                    {
+                        Assert.That(captured.DeltaError.Replace("\r\n", "\n"), Is.EqualTo(message));
+                        break;
+                    }
+
+                    Assert.That(captured.DeltaVerification, Is.Not.Null);
+                    if (properties != null)
+                    {
+                        foreach (var property in properties)
+                        {
+                            var dv = JObject.FromObject(captured.DeltaVerification);
+                            string value;
+                            if (property.Key.Contains("."))
+                            {
+                                var props = property.Key.Split(new[] {'.'}, StringSplitOptions.RemoveEmptyEntries);
+                                value = dv[props[0]][props[1]].ToString();
+                            }
+                            else
+                            {
+                                value = dv[property.Key].ToString();
+                            }
+
+                            AssertServiceMessageValue(property.Key, property.Value, value, resolveConstraint);
+                        }
+                    }
+
+                    break;
+            }
+        }
+
+        static void AssertServiceMessageValue(string property, object expected, string actual, IResolveConstraint resolveConstraint)
+        {
+            Assert.That(actual, Is.Not.Null);
+            Assert.That(actual, Is.Not.Empty);
+            Assert.That(actual.Equals(expected), resolveConstraint,
+                "Expected property '{0}' to have value '{1}' but was actually '{2}'", property,
+                expected, actual);
+        }
+
+        public void AssertNoOutput(string expectedOutput)
+        {
+            var allOutput = string.Join(Environment.NewLine, captured.Infos);
+
+            Assert.That(allOutput, Does.Not.Contain(expectedOutput));
+        }
+
+        public void AssertOutput(string expectedOutput)
+        {
+            var allOutput = string.Join(Environment.NewLine, captured.Infos);
+
+            Assert.That(allOutput, Does.Contain(expectedOutput));
+        }
+
+        public void AssertOutputContains(string expected)
+        {
+            var allOutput = string.Join(Environment.NewLine, captured.Infos);
+
+            allOutput.Should().Contain(expected);
+        }
+
+        public void AssertOutputMatches(string regex, string message = null)
+        {
+            var allOutput = string.Join(Environment.NewLine, captured.Infos);
+
+            Assert.That(allOutput, Does.Match(regex), message);
+        }
+
+        public void AssertNoOutputMatches(string regex)
+        {
+            var allOutput = string.Join(Environment.NewLine, captured.Infos);
+
+            Assert.That(allOutput, Does.Not.Match(regex));
+        }
+
+        public string GetOutputForLineContaining(string expectedOutput)
+        {
+            var found = captured.Infos.SingleOrDefault(i => i.ContainsIgnoreCase(expectedOutput));
+            found.Should().NotBeNull($"'{expectedOutput}' should exist");
+            return found;
+        }
+
+        public void AssertErrorOutput(string expectedOutputFormat, params object[] args)
+        {
+            AssertErrorOutput(String.Format(expectedOutputFormat, args));
+        }
+
+        public void AssertErrorOutput(string expectedOutput, bool noNewLines = false)
+        {
+            var separator = noNewLines ? String.Empty : Environment.NewLine;
+            var allOutput = string.Join(separator, captured.Errors);
+            Assert.That(allOutput, Does.Contain(expectedOutput));
+        }
+
+        //Assuming we print properties like:
+        //"name: expectedValue"
+        public void AssertPropertyValue(string name, params string[] expectedValues)
+        {
+            var title = name + ":";
+            string line = GetOutputForLineContaining(title);
+
+            line.Replace(title, "").Should().BeOneOf(expectedValues);
+        }
+
+        public void AssertProcessNameAndId(string processName)
+        {
+            AssertOutputMatches(@"HostProcess: (Calamari|dotnet|mono-sgen32|mono-sgen64|mono-sgen) \([0-9]+\)", "Calamari process name and id are printed");
+            AssertOutputMatches($@"HostProcess: ({processName}|mono-sgen32|mono-sgen64|mono-sgen) \([0-9]+\)", $"{processName} process name and id are printed");
+        }
+    }
+}

--- a/source/Calamari.Tests.Shared/Helpers/CaptureCommandInvocationOutputSink.cs
+++ b/source/Calamari.Tests.Shared/Helpers/CaptureCommandInvocationOutputSink.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using Calamari.Common.Plumbing.Commands;
+using Calamari.Common.Plumbing.ServiceMessages;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Tests.Shared.LogParser;
+using ServiceMessageParser = Calamari.Common.Plumbing.ServiceMessages.ServiceMessageParser;
+
+namespace Calamari.Tests.Helpers
+{
+    //Ideally sourced directly from Octopus.Worker repo
+    public class CaptureCommandInvocationOutputSink : ICommandInvocationOutputSink
+    {
+        readonly List<string> all = new List<string>();
+        readonly List<string> infos = new List<string>();
+        readonly List<string> errors = new List<string>();
+        readonly ServiceMessageParser serviceMessageParser;
+        readonly IVariables outputVariables = new CalamariVariables();
+
+        public CaptureCommandInvocationOutputSink()
+        {
+            serviceMessageParser = new ServiceMessageParser(ParseServiceMessage);
+        }
+
+        public void WriteInfo(string line)
+        {
+            serviceMessageParser.Parse(line);
+            all.Add(line);
+            infos.Add(line);
+        }
+
+        public void WriteError(string line)
+        {
+            all.Add(line);
+            errors.Add(line);
+        }
+
+        public IVariables OutputVariables => outputVariables;
+
+        public IList<string> Infos => infos;
+
+        public IList<string> Errors => errors;
+
+        public IList<string> AllMessages => all;
+
+        public bool CalamariFoundPackage { get; protected set; }
+
+        public FoundPackage FoundPackage { get; protected set; }
+
+        public DeltaPackage DeltaVerification { get; protected set; }
+
+        public string DeltaError { get; protected set; }
+
+        void ParseServiceMessage(ServiceMessage message)
+        {
+            switch (message.Name)
+            {
+                case ServiceMessageNames.SetVariable.Name:
+                    var variableName = message.GetValue(ServiceMessageNames.SetVariable.NameAttribute);
+                    var variableValue = message.GetValue(ServiceMessageNames.SetVariable.ValueAttribute);
+
+                    if (!string.IsNullOrWhiteSpace(variableName))
+                        outputVariables.Set(variableName, variableValue);
+                    break;
+                case ServiceMessageNames.CalamariFoundPackage.Name:
+                    CalamariFoundPackage = true;
+                    break;
+                case ServiceMessageNames.FoundPackage.Name:
+                    var foundPackageId = message.GetValue(ServiceMessageNames.FoundPackage.IdAttribute);
+                    var foundPackageVersion = message.GetValue(ServiceMessageNames.FoundPackage.VersionAttribute);
+                    var foundPackageVersionFormat = message.GetValue(ServiceMessageNames.FoundPackage.VersionFormat );
+                    var foundPackageHash = message.GetValue(ServiceMessageNames.FoundPackage.HashAttribute);
+                    var foundPackageRemotePath = message.GetValue(ServiceMessageNames.FoundPackage.RemotePathAttribute);
+                    var fileExtension = message.GetValue(ServiceMessageNames.FoundPackage.FileExtensionAttribute);
+                    FoundPackage = new FoundPackage(foundPackageId, foundPackageVersion, foundPackageVersionFormat, foundPackageRemotePath,
+                        foundPackageHash, fileExtension);
+                    break;
+                case ServiceMessageNames.PackageDeltaVerification.Name:
+                    var pdvHash = message.GetValue(ServiceMessageNames.PackageDeltaVerification.HashAttribute);
+                    var pdvSize = message.GetValue(ServiceMessageNames.PackageDeltaVerification.SizeAttribute);
+                    var pdvRemotePath =
+                        message.GetValue(ServiceMessageNames.PackageDeltaVerification.RemotePathAttribute);
+                    DeltaError = message.GetValue(ServiceMessageNames.PackageDeltaVerification.Error);
+                    if (pdvHash != null)
+                    {
+                        DeltaVerification = new DeltaPackage(pdvRemotePath, pdvHash, long.Parse(pdvSize));
+                    }
+
+                    break;
+            }
+        }
+    }
+}

--- a/source/Calamari.Tests.Shared/Helpers/TestCommandLineRunner.cs
+++ b/source/Calamari.Tests.Shared/Helpers/TestCommandLineRunner.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.Commands;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.ServiceMessages;
+using Calamari.Common.Plumbing.Variables;
+
+namespace Calamari.Tests.Helpers
+{
+    public class TestCommandLineRunner : CommandLineRunner
+    {
+        readonly IVariables variables;
+
+        public TestCommandLineRunner(ILog log, IVariables variables) : base(log, variables)
+        {
+            this.variables = variables;
+            Output = new CaptureCommandInvocationOutputSink();
+        }
+
+        public CaptureCommandInvocationOutputSink Output { get; }
+
+        protected override List<ICommandInvocationOutputSink> GetCommandOutputs(CommandLineInvocation invocation)
+            => new List<ICommandInvocationOutputSink>()
+            {
+                Output,
+                new ServiceMessageCommandInvocationOutputSink(variables)
+            };
+    }
+}

--- a/source/Sashimi.Tests.Shared/Server/ExecutableHelper.cs
+++ b/source/Sashimi.Tests.Shared/Server/ExecutableHelper.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using System.Text;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing;
+
+namespace Sashimi.Tests.Shared.Server
+{
+    public static class ExecutableHelper
+    {
+        public static void AddExecutePermission(string exePath)
+        {
+            if (CalamariEnvironment.IsRunningOnWindows)
+                return;
+
+            var stdOut = new StringBuilder();
+            var stdError = new StringBuilder();
+            var result = SilentProcessRunner.ExecuteCommand("chmod",
+                                                            $"+x {exePath}",
+                                                            Path.GetDirectoryName(exePath),
+                                                            s => stdOut.AppendLine(s),
+                                                            s => stdError.AppendLine(s));
+
+            if (result.ExitCode != 0)
+                throw new Exception(stdOut.ToString() + stdError);
+        }
+    }
+}

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -27,7 +27,7 @@ namespace Sashimi.Tests.Shared.Server
 {
     class TestCalamariCommandBuilder<TCalamariProgram> : ICalamariCommandBuilder where TCalamariProgram : CalamariFlavourProgram
     {
-        const string CalamaribinariesLocationEnvironmentVariable = "CalamariBinaries_RelativePath";
+        const string CalamariBinariesLocationEnvironmentVariable = "CalamariBinaries_RelativePath";
 
         static class InProcOutProcOverride
         {
@@ -300,7 +300,7 @@ namespace Sashimi.Tests.Shared.Server
             if (TestEnvironment.IsCI)
             {
                 //This is where Teamcity puts the Calamari binaries
-                var calamaribinariesFolder = Environment.GetEnvironmentVariable(CalamaribinariesLocationEnvironmentVariable);
+                var calamaribinariesFolder = Environment.GetEnvironmentVariable(CalamariBinariesLocationEnvironmentVariable);
                 return AddExeExtensionIfNecessary(Path.GetFullPath(Path.Combine(sashimiTestFolder, calamaribinariesFolder, calamariFlavour)));
             }
 

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -301,19 +301,19 @@ namespace Sashimi.Tests.Shared.Server
             {
                 //This is where Teamcity puts the Calamari binaries
                 var calamaribinariesFolder = Environment.GetEnvironmentVariable(CalamaribinariesLocationEnvironmentVariable);
-                return AddExeIfNecessary(Path.GetFullPath(Path.Combine(sashimiTestFolder, calamaribinariesFolder, calamariFlavour)));
+                return AddExeExtensionIfNecessary(Path.GetFullPath(Path.Combine(sashimiTestFolder, calamaribinariesFolder, calamariFlavour)));
             }
 
             //Running locally - change these to your liking
-            var configuration = "Debug";
-            var targetFramework = "net452";
-            var runtime = "win-x64";
+            var configuration = "Debug"; //Debug;Release
+            var targetFramework = "net452"; //net452;netcoreapp3.1
+            var runtime = "win-x64"; //win-x64;linux-x64;osx-x64;linux-arm;linux-arm64
 
             //When running out of process locally, always publish so we get something runnable for NetCore
             var calamariProjectFolder = Path.GetFullPath(Path.Combine(sashimiTestFolder, "../../../..", calamariFlavour));
             DotNetPublish(calamariProjectFolder, configuration, targetFramework, runtime);
 
-            return AddExeIfNecessary(Path.Combine(calamariProjectFolder, "bin", "Debug", targetFramework, runtime, "publish", calamariFlavour));
+            return AddExeExtensionIfNecessary(Path.Combine(calamariProjectFolder, "bin", "Debug", targetFramework, runtime, "publish", calamariFlavour));
 
             void DotNetPublish(string calamariProjectFolder, string configuration, string targetFramework, string runtime)
             {
@@ -329,7 +329,7 @@ namespace Sashimi.Tests.Shared.Server
                     throw new Exception(stdOut.ToString() + stdError);
             }
 
-            string AddExeIfNecessary(string exePath)
+            string AddExeExtensionIfNecessary(string exePath)
             {
                 if (File.Exists(exePath))
                     return exePath;
@@ -338,7 +338,7 @@ namespace Sashimi.Tests.Shared.Server
                 if (File.Exists(withExeExtension))
                     return withExeExtension;
 
-                throw new Exception($"Calamari exe doesn't exist on disk: '{exePath}'");
+                throw new Exception($"Calamari exe doesn't exist on disk: '{exePath}(.exe)'");
             }
         }
 

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -1,25 +1,41 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
+using Calamari;
 using Calamari.Common;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing;
 using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Tests.Helpers;
 using Calamari.Tests.Shared;
 using Calamari.Tests.Shared.Helpers;
 using Calamari.Tests.Shared.LogParser;
-using Sashimi.Server.Contracts;
 using Sashimi.Server.Contracts.ActionHandlers;
 using Sashimi.Server.Contracts.Calamari;
 using Sashimi.Server.Contracts.CommandBuilders;
 using Sashimi.Server.Contracts.DeploymentTools;
+using KnownVariables = Sashimi.Server.Contracts.KnownVariables;
 
 namespace Sashimi.Tests.Shared.Server
 {
     class TestCalamariCommandBuilder<TCalamariProgram> : ICalamariCommandBuilder where TCalamariProgram : CalamariFlavourProgram
     {
+        const string CalamaribinariesLocationEnvironmentVariable = "CalamariBinaries_RelativePath";
+
+        static class InProcOutProcOverride
+        {
+            public static readonly string EnvironmentVariable = "Test_Calamari_InProc_OutProc_Override";
+            public static readonly string InProcValue = "InProc";
+            public static readonly string OutProcValue = "OutProc";
+        }
+
         public TestCalamariCommandBuilder(CalamariFlavour calamariFlavour, string calamariCommand)
         {
             CalamariFlavour = calamariFlavour;
@@ -172,6 +188,27 @@ namespace Sashimi.Tests.Shared.Server
 
         IActionHandlerResult ExecuteActionHandler(List<string> args)
         {
+            var inProcOutProcOverride = Environment.GetEnvironmentVariable(InProcOutProcOverride.EnvironmentVariable);
+            if (!string.IsNullOrEmpty(inProcOutProcOverride))
+            {
+                if (InProcOutProcOverride.InProcValue.Equals(inProcOutProcOverride, StringComparison.OrdinalIgnoreCase))
+                    return ExecuteActionHandlerInProc(args);
+
+                if (InProcOutProcOverride.OutProcValue.Equals(inProcOutProcOverride, StringComparison.OrdinalIgnoreCase))
+                    return ExecuteActionHandlerOutProc(args);
+
+                throw new Exception($"'{InProcOutProcOverride.EnvironmentVariable}' environment variable must be '{InProcOutProcOverride.InProcValue}' or '{InProcOutProcOverride.OutProcValue}'");
+            }
+
+            if (TestEnvironment.IsCI)
+                return ExecuteActionHandlerOutProc(args);
+            else
+                return ExecuteActionHandlerInProc(args);
+        }
+
+        IActionHandlerResult ExecuteActionHandlerInProc(List<string> args)
+        {
+            Console.WriteLine("Running Calamari InProc");
             AssertMatchingCalamariFlavour();
 
             var inMemoryLog = new InMemoryLog();
@@ -214,6 +251,120 @@ namespace Sashimi.Tests.Shared.Server
                 outputFilter.TestOutputVariables, outputFilter.Actions,
                 outputFilter.ServiceMessages, outputFilter.ResultMessage, outputFilter.Artifacts,
                 serverInMemoryLog.ToString());
+        }
+
+        IActionHandlerResult ExecuteActionHandlerOutProc(List<string> args)
+        {
+            Console.WriteLine("Running Calamari OutProc");
+            using (var variablesFile = new TemporaryFile(Path.GetTempFileName()))
+            {
+                variables.Save(variablesFile.FilePath);
+
+                var calamariFullPath = GetOutProcCalamariExePath();
+                Console.WriteLine("Running Calamari from: "+ calamariFullPath);
+
+                MakeExecutable(calamariFullPath);
+
+                var commandLine = new CommandLine(calamariFullPath);
+                foreach (var argument in args)
+                    commandLine = commandLine.Argument(argument);
+
+                var calamariResult = Invoke(commandLine);
+
+                var capturedOutput = calamariResult.CapturedOutput;
+
+                var serverInMemoryLog = new ServerInMemoryLog();
+
+                var outputFilter = new ScriptOutputFilter(serverInMemoryLog);
+                foreach (var text in capturedOutput.Errors)
+                {
+                    outputFilter.Write(ProcessOutputSource.StdErr, text);
+                }
+
+                foreach (var text in capturedOutput.Infos)
+                {
+                    outputFilter.Write(ProcessOutputSource.StdOut, text);
+                }
+
+                return new TestActionHandlerResult(calamariResult.ExitCode,
+                    outputFilter.TestOutputVariables, outputFilter.Actions,
+                    outputFilter.ServiceMessages, outputFilter.ResultMessage, outputFilter.Artifacts,
+                    serverInMemoryLog.ToString());
+            }
+        }
+
+        static void MakeExecutable(string calamariFullPath)
+        {
+            if (CalamariEnvironment.IsRunningOnWindows)
+                return;
+
+            var stdOut = new StringBuilder();
+            var stdError = new StringBuilder();
+            var result = SilentProcessRunner.ExecuteCommand("chmod",
+                $"+x {calamariFullPath}",
+                Path.GetDirectoryName(calamariFullPath),
+                s => stdOut.AppendLine(s),
+                s => stdError.AppendLine(s));
+
+            if (result.ExitCode != 0)
+                throw new Exception(stdOut.ToString() + stdError);
+        }
+
+        string GetOutProcCalamariExePath()
+        {
+            var calamariFlavour = typeof(TCalamariProgram).Assembly.GetName().Name;
+            var sashimiTestFolder = Path.GetDirectoryName(typeof(TCalamariProgram).Assembly.FullLocalPath());
+
+            if (TestEnvironment.IsCI)
+            {
+                //This is where Teamcity puts the Calamari binaries
+                var calamaribinariesFolder = Environment.GetEnvironmentVariable(CalamaribinariesLocationEnvironmentVariable);
+                return AddExeIfNecessary(Path.GetFullPath(Path.Combine(sashimiTestFolder, calamaribinariesFolder, calamariFlavour)));
+            }
+
+            //Running locally - change these to your liking
+            var configuration = "Debug";
+            var targetFramework = "net452";
+            var runtime = "win-x64";
+
+            //When running out of process locally, always publish so we get something runnable for NetCore
+            var calamariProjectFolder = Path.GetFullPath(Path.Combine(sashimiTestFolder, "../../../..", calamariFlavour));
+            DotNetPublish(calamariProjectFolder, configuration, targetFramework, runtime);
+
+            return AddExeIfNecessary(Path.Combine(calamariProjectFolder, "bin", "Debug", targetFramework, runtime, "publish", calamariFlavour));
+
+            void DotNetPublish(string calamariProjectFolder, string configuration, string targetFramework, string runtime)
+            {
+                var stdOut = new StringBuilder();
+                var stdError = new StringBuilder();
+                var result = SilentProcessRunner.ExecuteCommand($"dotnet",
+                    $"publish --framework {targetFramework} --configuration {configuration} --runtime {runtime}",
+                    calamariProjectFolder,
+                    s => stdOut.AppendLine(s),
+                    s => stdError.AppendLine(s));
+
+                if (result.ExitCode != 0)
+                    throw new Exception(stdOut.ToString() + stdError);
+            }
+
+            string AddExeIfNecessary(string exePath)
+            {
+                if (File.Exists(exePath))
+                    return exePath;
+
+                var withExeExtension = exePath + ".exe";
+                if (File.Exists(withExeExtension))
+                    return withExeExtension;
+
+                throw new Exception($"Calamari exe doesn't exist on disk: '{exePath}'");
+            }
+        }
+
+        CalamariResult Invoke(CommandLine command, IVariables? variables = null)
+        {
+            var runner = new TestCommandLineRunner(ConsoleLog.Instance, variables ?? new CalamariVariables());
+            var result = runner.Execute(command.Build());
+            return new CalamariResult(result.ExitCode, runner.Output);
         }
 
         void Copy(string sourcePath, string destinationPath)

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -255,15 +255,14 @@ namespace Sashimi.Tests.Shared.Server
 
         IActionHandlerResult ExecuteActionHandlerOutProc(List<string> args)
         {
-            Console.WriteLine("Running Calamari OutProc");
             using (var variablesFile = new TemporaryFile(Path.GetTempFileName()))
             {
                 variables.Save(variablesFile.FilePath);
 
                 var calamariFullPath = GetOutProcCalamariExePath();
-                Console.WriteLine("Running Calamari from: "+ calamariFullPath);
+                Console.WriteLine("Running Calamari OutProc from: "+ calamariFullPath);
 
-                MakeExecutable(calamariFullPath);
+                ExecutableHelper.AddExecutePermission(calamariFullPath);
 
                 var commandLine = new CommandLine(calamariFullPath);
                 foreach (var argument in args)
@@ -291,23 +290,6 @@ namespace Sashimi.Tests.Shared.Server
                     outputFilter.ServiceMessages, outputFilter.ResultMessage, outputFilter.Artifacts,
                     serverInMemoryLog.ToString());
             }
-        }
-
-        static void MakeExecutable(string calamariFullPath)
-        {
-            if (CalamariEnvironment.IsRunningOnWindows)
-                return;
-
-            var stdOut = new StringBuilder();
-            var stdError = new StringBuilder();
-            var result = SilentProcessRunner.ExecuteCommand("chmod",
-                $"+x {calamariFullPath}",
-                Path.GetDirectoryName(calamariFullPath),
-                s => stdOut.AppendLine(s),
-                s => stdError.AppendLine(s));
-
-            if (result.ExitCode != 0)
-                throw new Exception(stdOut.ToString() + stdError);
         }
 
         string GetOutProcCalamariExePath()

--- a/source/Sashimi.Tests.Shared/TestEnvironment.cs
+++ b/source/Sashimi.Tests.Shared/TestEnvironment.cs
@@ -1,12 +1,14 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Calamari;
 
 namespace Sashimi.Tests.Shared
 {
-    public static class TestEnvironment 
+    public static class TestEnvironment
     {
         public static readonly string AssemblyLocalPath = typeof(TestEnvironment).Assembly.FullLocalPath();
         public static readonly string CurrentWorkingDirectory = Path.GetDirectoryName(AssemblyLocalPath);
+        public static readonly bool IsCI = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TEAMCITY_VERSION"));
 
         public static string GetTestPath(params string[] paths)
         {


### PR DESCRIPTION
We're changing the Sashimi builds (currently just 1 cake file with build+test) and splitting it up so we can run tests on multiple platforms like [Calamari ](https://build.octopushq.com/project.html?projectId=OctopusDeploy_CalamariNetCore) does.

The big change is that now we can invoke Calamari out of process (`IActionHandlers` are always NetCore3.1, but Calamari can be `netfx`).

The new test helper classes were copied from Calamari. They can be deleted once we extract a `Calamari.Tests.Shared` dll to share code.

## Build Tree
The new build tree is [here](https://build.octopushq.com/project.html?projectId=OctopusDeploy_LIbraries_Sashimi). Some notable differences to Calamari are:
- There's no Mono testing (the decision was that it wasn't worth the trouble, and most of the steps moved to Sashimi are again cloud targets anyway)
- There's no Sashimi-Calamari E2E testing for Windows 2008/2008R2 since they don't support dotnet Core (that ActionHandler needs)
- There's no platform agnostic testing, these libraries should be small enough that this time saving wouldn't be worth the maintenance effort

## Build Steps
Most of the logic is in the [build template](https://build.octopushq.com/admin/editBuildRunners.html?id=template:OctopusDeploy_LIbraries_Sashimi_SashimiTerraform_NetcoreTestingNetcoreTesting).

The build configs grab the right binaries by overriding the `CalamariFlavour` and `dotnet_runtime` Teamcity parameters:
![image](https://user-images.githubusercontent.com/2888279/88135338-220a1400-cc2a-11ea-939a-018052bb3f27.png)

Then we run the `Sashimi-Calamari E2E` tests and `Calamari-only` tests in 2 steps:
![image](https://user-images.githubusercontent.com/2888279/88135311-13bbf800-cc2a-11ea-8cc3-e7f2c83c8bca.png)
