### PR TITLE
Get Mono tests working

### DIFF
--- a/source/Sashimi.Tests.Shared/Server/ActionHandlerTestBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/ActionHandlerTestBuilder.cs
@@ -12,14 +12,14 @@ namespace Sashimi.Tests.Shared.Server
 {
     public static class ActionHandlerTestBuilder
     {
-        public static ActionHandlerTestBuilder<TCalamari> Create<TActionHandler, TCalamari>() 
+        public static ActionHandlerTestBuilder<TCalamari> Create<TActionHandler, TCalamari>()
             where TActionHandler : IActionHandler
             where TCalamari : CalamariFlavourProgram
         {
             return new ActionHandlerTestBuilder<TCalamari>(typeof(TActionHandler));
         }
-        
-        public static ActionHandlerTestBuilder<TCalamari> Create<TCalamari>(Type actionHandlerType) 
+
+        public static ActionHandlerTestBuilder<TCalamari> Create<TCalamari>(Type actionHandlerType)
             where TCalamari : CalamariFlavourProgram
         {
             return new ActionHandlerTestBuilder<TCalamari>(actionHandlerType);
@@ -35,8 +35,8 @@ namespace Sashimi.Tests.Shared.Server
             return context;
         }
     }
-    
-    public class ActionHandlerTestBuilder<TCalamariProgram> 
+
+    public class ActionHandlerTestBuilder<TCalamariProgram>
         where TCalamariProgram : CalamariFlavourProgram
     {
         readonly List<Action<TestActionHandlerContext<TCalamariProgram>>> arrangeActions;
@@ -71,7 +71,7 @@ namespace Sashimi.Tests.Shared.Server
 
             foreach (var arrangeAction in arrangeActions)
             {
-                arrangeAction?.Invoke(context);    
+                arrangeAction?.Invoke(context);
             }
 
             TestActionHandlerResult result;
@@ -80,11 +80,13 @@ namespace Sashimi.Tests.Shared.Server
                 var actionHandler = (IActionHandler) container.Resolve(actionHandlerType);
 
                 result = (TestActionHandlerResult) actionHandler.Execute(context);
+
+                Console.WriteLine(result.FullLog);
             }
 
             if (assertWasSuccess)
             {
-                result.WasSuccessful.Should().BeTrue($"{actionHandlerType} execute result was unsuccessful");
+                result.WasSuccessful.Should().BeTrue($"{actionHandlerType} execute result was unsuccessful.");
             }
             assertAction?.Invoke(result);
 

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -262,8 +262,6 @@ namespace Sashimi.Tests.Shared.Server
                 var calamariFullPath = GetOutProcCalamariExePath();
                 Console.WriteLine("Running Calamari OutProc from: "+ calamariFullPath);
 
-                ExecutableHelper.AddExecutePermission(calamariFullPath);
-
                 var commandLine = CreateCommandLine(calamariFullPath);
                 foreach (var argument in args)
                     commandLine = commandLine.Argument(argument);
@@ -301,6 +299,7 @@ namespace Sashimi.Tests.Shared.Server
                 return commandLine;
             }
 
+            ExecutableHelper.AddExecutePermission(calamariFullPath);
             return new CommandLine(calamariFullPath);
         }
 

--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -264,7 +264,7 @@ namespace Sashimi.Tests.Shared.Server
 
                 ExecutableHelper.AddExecutePermission(calamariFullPath);
 
-                var commandLine = new CommandLine(calamariFullPath);
+                var commandLine = CreateCommandLine(calamariFullPath);
                 foreach (var argument in args)
                     commandLine = commandLine.Argument(argument);
 
@@ -290,6 +290,18 @@ namespace Sashimi.Tests.Shared.Server
                     outputFilter.ServiceMessages, outputFilter.ResultMessage, outputFilter.Artifacts,
                     serverInMemoryLog.ToString());
             }
+        }
+
+        static CommandLine CreateCommandLine(string calamariFullPath)
+        {
+            if (!CalamariEnvironment.IsRunningOnWindows && calamariFullPath.EndsWith(".exe"))
+            {
+                var commandLine = new CommandLine("mono");
+                commandLine.Argument(calamariFullPath);
+                return commandLine;
+            }
+
+            return new CommandLine(calamariFullPath);
         }
 
         string GetOutProcCalamariExePath()


### PR DESCRIPTION
On some Linux/Mac environments, you have to call `mono Calamari.exe` rather than `Calamari.exe`, so this optionally changes the command line invocation  when we try to run an `.exe` file under a non-Windows environment (Mono).

Also print the Calamari logs so we can find out why a test failed