### PR TITLE
Add dynamic function registration for aws and azure account

### DIFF
--- a/source/Sashimi.Aws.Accounts.Tests/AmazonWebServicesAccountServiceMessageHandlerFixture.cs
+++ b/source/Sashimi.Aws.Accounts.Tests/AmazonWebServicesAccountServiceMessageHandlerFixture.cs
@@ -21,7 +21,7 @@ namespace Sashimi.Aws.Accounts.Tests
         public void Ctor_Properties_ShouldBeInitializedCorrectly()
         {
             serviceMessageHandler.AuditEntryDescription.Should().Be("AWS Account");
-            serviceMessageHandler.ServiceMessageName.Should().Be(CreateAwsAccountServiceMessagePropertyNames.Name);
+            serviceMessageHandler.ServiceMessageName.Should().Be(CreateAwsAccountServiceMessagePropertyNames.CreateAccountName);
         }
 
         [Test]
@@ -33,16 +33,16 @@ namespace Sashimi.Aws.Accounts.Tests
 
             details.Should().BeOfType<AmazonWebServicesAccountDetails>();
             var amazonWebServicesAccountDetails = (AmazonWebServicesAccountDetails)details;
-            amazonWebServicesAccountDetails.AccessKey.Should().Be(properties[CreateAwsAccountServiceMessagePropertyNames.AccessKey]);
-            amazonWebServicesAccountDetails.SecretKey.Should().Be(properties[CreateAwsAccountServiceMessagePropertyNames.SecretKey]);
+            amazonWebServicesAccountDetails.AccessKey.Should().Be(properties[CreateAwsAccountServiceMessagePropertyNames.AccessKeyAttribute]);
+            amazonWebServicesAccountDetails.SecretKey.Should().Be(properties[CreateAwsAccountServiceMessagePropertyNames.SecretKeyAttribute]);
         }
 
         static IDictionary<string, string> GetMessageProperties()
         {
             return new Dictionary<string, string>
             {
-                { CreateAwsAccountServiceMessagePropertyNames.AccessKey, "AccessKey" },
-                { CreateAwsAccountServiceMessagePropertyNames.SecretKey, "SecretKey" }
+                { CreateAwsAccountServiceMessagePropertyNames.AccessKeyAttribute, "AccessKey" },
+                { CreateAwsAccountServiceMessagePropertyNames.SecretKeyAttribute, "SecretKey" }
             };
         }
     }

--- a/source/Sashimi.Aws.Accounts/AmazonWebServicesAccountServiceMessageHandler.cs
+++ b/source/Sashimi.Aws.Accounts/AmazonWebServicesAccountServiceMessageHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using Octopus.Data.Model;
 using Sashimi.Server.Contracts;
 using Sashimi.Server.Contracts.Accounts;
@@ -10,13 +9,25 @@ namespace Sashimi.Aws.Accounts
     class AmazonWebServicesAccountServiceMessageHandler : ICreateAccountDetailsServiceMessageHandler
     {
         public string AuditEntryDescription => "AWS Account";
-        public string ServiceMessageName => CreateAwsAccountServiceMessagePropertyNames.Name;
-        public IEnumerable<ScriptFunctionRegistration> ScriptFunctionRegistrations { get; } = Enumerable.Empty<ScriptFunctionRegistration>();
+        public string ServiceMessageName => CreateAwsAccountServiceMessagePropertyNames.CreateAccountName;
+        public IEnumerable<ScriptFunctionRegistration> ScriptFunctionRegistrations { get; } = new List<ScriptFunctionRegistration>
+        {
+            new ScriptFunctionRegistration("OctopusAwsAccount",
+                                           "Creates a new Amazon Web Services Account.",
+                                           CreateAwsAccountServiceMessagePropertyNames.CreateAccountName,
+                                           new Dictionary<string, FunctionParameter>
+                                           {
+                                               { CreateAwsAccountServiceMessagePropertyNames.NameAttribute, new FunctionParameter(ParameterType.String) },
+                                               { CreateAwsAccountServiceMessagePropertyNames.SecretKeyAttribute, new FunctionParameter(ParameterType.String) },
+                                               { CreateAwsAccountServiceMessagePropertyNames.AccessKeyAttribute, new FunctionParameter(ParameterType.String) },
+                                               { CreateAwsAccountServiceMessagePropertyNames.UpdateIfExistingAttribute, new FunctionParameter(ParameterType.Bool) }
+                                           })
+        };
 
         public AccountDetails CreateAccountDetails(IDictionary<string, string> properties)
         {
-            properties.TryGetValue(CreateAwsAccountServiceMessagePropertyNames.AccessKey, out var accessKey);
-            properties.TryGetValue(CreateAwsAccountServiceMessagePropertyNames.SecretKey, out var secretKey);
+            properties.TryGetValue(CreateAwsAccountServiceMessagePropertyNames.AccessKeyAttribute, out var accessKey);
+            properties.TryGetValue(CreateAwsAccountServiceMessagePropertyNames.SecretKeyAttribute, out var secretKey);
 
             return new AmazonWebServicesAccountDetails
             {
@@ -27,9 +38,12 @@ namespace Sashimi.Aws.Accounts
 
         internal static class CreateAwsAccountServiceMessagePropertyNames
         {
-            public const string Name = "create-awsaccount";
-            public const string SecretKey = "secretKey";
-            public const string AccessKey = "accessKey";
+            public const string CreateAccountName = "create-awsaccount";
+
+            public const string UpdateIfExistingAttribute = "updateIfExisting";
+            public const string NameAttribute = "name";
+            public const string SecretKeyAttribute = "secretKey";
+            public const string AccessKeyAttribute = "accessKey";
         }
     }
 }

--- a/source/Sashimi.Azure.Accounts.Tests/AzureServicePrincipalAccountServiceMessageHandlerFixture.cs
+++ b/source/Sashimi.Azure.Accounts.Tests/AzureServicePrincipalAccountServiceMessageHandlerFixture.cs
@@ -23,7 +23,7 @@ namespace Sashimi.Azure.Accounts.Tests
         public void Ctor_Properties_ShouldBeInitializedCorrectly()
         {
             serviceMessageHandler.AuditEntryDescription.Should().Be("Azure Service Principal account");
-            serviceMessageHandler.ServiceMessageName.Should().Be(CreateAzureAccountServiceMessagePropertyNames.Name);
+            serviceMessageHandler.ServiceMessageName.Should().Be(CreateAzureAccountServiceMessagePropertyNames.CreateAccountName);
         }
 
         [Test]

--- a/source/Sashimi.Azure.Accounts/AzureServicePrincipalAccountServiceMessageHandler.cs
+++ b/source/Sashimi.Azure.Accounts/AzureServicePrincipalAccountServiceMessageHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using Octopus.Data.Model;
 using Sashimi.Server.Contracts;
 using Sashimi.Server.Contracts.Accounts;
@@ -10,8 +9,25 @@ namespace Sashimi.Azure.Accounts
     class AzureServicePrincipalAccountServiceMessageHandler : ICreateAccountDetailsServiceMessageHandler
     {
         public string AuditEntryDescription => "Azure Service Principal account";
-        public string ServiceMessageName => CreateAzureAccountServiceMessagePropertyNames.Name;
-        public IEnumerable<ScriptFunctionRegistration> ScriptFunctionRegistrations { get; } = Enumerable.Empty<ScriptFunctionRegistration>();
+        public string ServiceMessageName => CreateAzureAccountServiceMessagePropertyNames.CreateAccountName;
+        public IEnumerable<ScriptFunctionRegistration> ScriptFunctionRegistrations { get; } = new List<ScriptFunctionRegistration>
+        {
+            new ScriptFunctionRegistration("OctopusAzureServicePrincipalAccount",
+                                           "Creates a new Azure Service Principal Account.",
+                                           CreateAzureAccountServiceMessagePropertyNames.CreateAccountName,
+                                           new Dictionary<string, FunctionParameter>
+                                           {
+                                               { CreateAzureAccountServiceMessagePropertyNames.NameAttribute, new FunctionParameter(ParameterType.String) },
+                                               { CreateAzureAccountServiceMessagePropertyNames.SubscriptionAttribute, new FunctionParameter(ParameterType.String) },
+                                               { CreateAzureAccountServiceMessagePropertyNames.ServicePrincipal.ApplicationAttribute, new FunctionParameter(ParameterType.String) },
+                                               { CreateAzureAccountServiceMessagePropertyNames.ServicePrincipal.TenantAttribute, new FunctionParameter(ParameterType.String) },
+                                               { CreateAzureAccountServiceMessagePropertyNames.ServicePrincipal.PasswordAttribute, new FunctionParameter(ParameterType.String) },
+                                               { CreateAzureAccountServiceMessagePropertyNames.ServicePrincipal.EnvironmentAttribute, new FunctionParameter(ParameterType.String, CreateAzureAccountServiceMessagePropertyNames.ServicePrincipal.EnvironmentAttribute) },
+                                               { CreateAzureAccountServiceMessagePropertyNames.ServicePrincipal.BaseUriAttribute, new FunctionParameter(ParameterType.String, CreateAzureAccountServiceMessagePropertyNames.ServicePrincipal.EnvironmentAttribute) },
+                                               { CreateAzureAccountServiceMessagePropertyNames.ServicePrincipal.ResourceManagementBaseUriAttribute, new FunctionParameter(ParameterType.String, CreateAzureAccountServiceMessagePropertyNames.ServicePrincipal.EnvironmentAttribute) },
+                                               { CreateAzureAccountServiceMessagePropertyNames.UpdateIfExistingAttribute, new FunctionParameter(ParameterType.Bool) }
+                                           })
+        };
 
         public AccountDetails CreateAccountDetails(IDictionary<string, string> properties)
         {
@@ -56,17 +72,19 @@ namespace Sashimi.Azure.Accounts
 
         internal static class CreateAzureAccountServiceMessagePropertyNames
         {
-            public const string Name = "create-azureaccount";
+            public const string CreateAccountName = "create-azureaccount";
 
-            public const string SubscriptionAttribute = "azSubscriptionId";
+            public const string NameAttribute = "name";
+            public const string UpdateIfExistingAttribute = "updateIfExisting";
+            public const string SubscriptionAttribute = "azureSubscriptionId";
             public static class ServicePrincipal
             {
-                public const string ApplicationAttribute = "azApplicationId";
-                public const string TenantAttribute = "azTenantId";
-                public const string PasswordAttribute = "azPassword";
-                public const string EnvironmentAttribute = "azEnvironment";
-                public const string BaseUriAttribute = "azBaseUri";
-                public const string ResourceManagementBaseUriAttribute = "azResourceManagementBaseUri";
+                public const string ApplicationAttribute = "azureApplicationId";
+                public const string TenantAttribute = "azureTenantId";
+                public const string PasswordAttribute = "azurePassword";
+                public const string EnvironmentAttribute = "azureEnvironment";
+                public const string BaseUriAttribute = "azureBaseUri";
+                public const string ResourceManagementBaseUriAttribute = "azureResourceManagementBaseUri";
             }
         }
     }


### PR DESCRIPTION
Move `New-OctopusAwsAccount` and `New-OctopusAzureServicePrincipalAccount` into `Sashimi` as script function registration(s), which make use of our `PowershellLanguage` generator at `Calamari` to generate the actual ps1 function(s). 

Please refer to its corresponding [Calamari PR](https://github.com/OctopusDeploy/Calamari/pull/662) & [Server PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/6624)