### PR TITLE
Fix AmazonWebServicesAccountVerifier to respect Octopus Proxy Settings

### DIFF
--- a/source/Sashimi.Aws.Accounts.Tests/AmazonWebServicesAccountVerifierFixture.cs
+++ b/source/Sashimi.Aws.Accounts.Tests/AmazonWebServicesAccountVerifierFixture.cs
@@ -1,0 +1,60 @@
+﻿using NUnit.Framework;
+using Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api;
+using System;
+using System.Net.Http;
+using NSubstitute;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading;
+using FluentAssertions;
+using Calamari.Tests.Shared;
+using Octopus.Data.Model;
+
+namespace Sashimi.Aws.Accounts.Tests
+{
+    [TestFixture]
+    public class AmazonWebServicesAccountVerifierFixture
+    {
+        [Test]
+        public void Verify_ShouldUseTheHttpClientProvidedFromTheOctopusHttpClientFactory()
+        {
+            var httpMessageHandler = new TestHttpClientHandler();
+            var awsHttpClientFactory = new AwsHttpClientFactory(new Lazy<IOctopusHttpClientFactory>(
+            () => GetOctopusHttpClientFactory(httpMessageHandler)));
+            var verifier = new AmazonWebServicesAccountVerifier(awsHttpClientFactory);
+
+            verifier.Verify(new AmazonWebServicesAccountDetails
+            {
+                AccessKey = ExternalVariables.Get(ExternalVariable.AwsAcessKey),
+                SecretKey = ExternalVariables.Get(ExternalVariable.AwsSecretKey).ToSensitiveString()
+            });
+
+            httpMessageHandler.RequestLog.Should().ContainSingle(r => r.RequestUri.AbsoluteUri == "https://sts.amazonaws.com/");
+        }
+
+        static IOctopusHttpClientFactory GetOctopusHttpClientFactory(HttpMessageHandler httpMessageHandler)
+        {
+            var httpClientFactory = Substitute.For<IOctopusHttpClientFactory>();
+            httpClientFactory.CreateClient().Returns(new HttpClient(httpMessageHandler));
+
+            return httpClientFactory;
+        }
+
+        class TestHttpClientHandler : HttpClientHandler
+        {
+            public TestHttpClientHandler()
+            {
+                RequestLog = new List<HttpRequestMessage>();
+            }
+
+            public IList<HttpRequestMessage> RequestLog { get; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                RequestLog.Add(request);
+
+                return base.SendAsync(request, cancellationToken);
+            }
+        }
+    }
+}

--- a/source/Sashimi.Aws.Accounts.Tests/Sashimi.Aws.Accounts.Tests.csproj
+++ b/source/Sashimi.Aws.Accounts.Tests/Sashimi.Aws.Accounts.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
@@ -14,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Calamari.Tests.Shared\Calamari.Tests.Shared.csproj" />
     <ProjectReference Include="..\Sashimi.Aws.Accounts\Sashimi.Aws.Accounts.csproj" />
     <ProjectReference Include="..\Sashimi.Tests.Shared\Sashimi.Tests.Shared.csproj" />
   </ItemGroup>

--- a/source/Sashimi.Aws.Accounts/AmazonWebServicesAccountModule.cs
+++ b/source/Sashimi.Aws.Accounts/AmazonWebServicesAccountModule.cs
@@ -8,6 +8,9 @@ namespace Sashimi.Aws.Accounts
     {
         protected override void Load(ContainerBuilder builder)
         {
+            builder.RegisterType<AwsHttpClientFactory>().AsSelf().SingleInstance();
+            builder.RegisterType<AmazonWebServicesAccountVerifier>().AsSelf().SingleInstance();
+
             builder.RegisterType<AmazonWebServicesAccountTypeProvider>().As<IAccountTypeProvider>().As<IContributeMappings>().SingleInstance();
         }
     }

--- a/source/Sashimi.Aws.Accounts/AmazonWebServicesAccountTypeProvider.cs
+++ b/source/Sashimi.Aws.Accounts/AmazonWebServicesAccountTypeProvider.cs
@@ -10,11 +10,16 @@ namespace Sashimi.Aws.Accounts
 {
     class AmazonWebServicesAccountTypeProvider : IAccountTypeProvider
     {
+        public AmazonWebServicesAccountTypeProvider(AmazonWebServicesAccountVerifier amazonWebServicesAccountVerifier)
+        {
+            Verifier = amazonWebServicesAccountVerifier;
+        }
+
         public AccountType AccountType { get; } = AccountTypes.AmazonWebServicesAccountType;
         public Type ModelType { get; } = typeof(AmazonWebServicesAccountDetails);
         public Type ApiType { get; } = typeof(AmazonWebServicesAccountResource);
         public IValidator Validator { get; } = new AmazonWebServicesAccountValidator();
-        public IVerifyAccount Verifier { get; } = new AmazonWebServicesAccountVerifier();
+        public IVerifyAccount Verifier { get; }
         public ICreateAccountDetailsServiceMessageHandler? CreateAccountDetailsServiceMessageHandler { get; } = new AmazonWebServicesAccountServiceMessageHandler();
 
         public IEnumerable<(string key, object value)> GetFeatureUsage(IAccountMetricContext context)

--- a/source/Sashimi.Aws.Accounts/AmazonWebServicesAccountVerifier.cs
+++ b/source/Sashimi.Aws.Accounts/AmazonWebServicesAccountVerifier.cs
@@ -1,19 +1,47 @@
+using System;
+using System.Net.Http;
 using Amazon.Runtime;
 using Amazon.SecurityToken;
 using Amazon.SecurityToken.Model;
+using Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api;
 using Sashimi.Server.Contracts.Accounts;
 
 namespace Sashimi.Aws.Accounts
 {
     class AmazonWebServicesAccountVerifier : IVerifyAccount
     {
+        readonly AmazonSecurityTokenServiceConfig tokenServiceConfig;
+
+        public AmazonWebServicesAccountVerifier(AwsHttpClientFactory awsHttpClientFactory)
+        {
+            tokenServiceConfig = new AmazonSecurityTokenServiceConfig
+            {
+                HttpClientFactory = awsHttpClientFactory
+            };
+        }
+
         public void Verify(AccountDetails account)
         {
-            var accountTyped = (AmazonWebServicesAccountDetails) account;
-            using (var client = new AmazonSecurityTokenServiceClient(new BasicAWSCredentials(accountTyped.AccessKey, accountTyped.SecretKey?.Value)))
+            var accountTyped = (AmazonWebServicesAccountDetails)account;
+            using (var client = new AmazonSecurityTokenServiceClient(new BasicAWSCredentials(accountTyped.AccessKey, accountTyped.SecretKey?.Value), tokenServiceConfig))
             {
                 client.GetCallerIdentityAsync(new GetCallerIdentityRequest()).Wait();
             }
+        }
+    }
+
+    class AwsHttpClientFactory : HttpClientFactory
+    {
+        readonly Lazy<IOctopusHttpClientFactory> httpClientFactory;
+
+        public AwsHttpClientFactory(Lazy<IOctopusHttpClientFactory> httpClientFactory)
+        {
+            this.httpClientFactory = httpClientFactory;
+        }
+
+        public override HttpClient CreateHttpClient(IClientConfig clientConfig)
+        {
+            return httpClientFactory.Value.CreateClient();
         }
     }
 }


### PR DESCRIPTION
Fix `AmazonWebServicesAccountVerifier` so it respects Octopus Proxy Setting(s) when testing the AWS account.

[Trello Card](https://trello.com/c/eBCDcahh/3608-octopus-ignoring-proxy-configuration-on-aws-accounts)

[Server PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/7202)