### PR TITLE
Move Features' variables into Sashimi

### DIFF
--- a/source/Server.Contracts/KnownVariables.cs
+++ b/source/Server.Contracts/KnownVariables.cs
@@ -195,5 +195,14 @@
                 public static readonly string EnableNoMatchWarning = "Octopus.Action.SubstituteInFiles.EnableNoMatchWarning";
             }
         }
+
+        public static class Features
+        {
+            public const string CustomScripts = "Octopus.Features.CustomScripts";
+            public const string ConfigurationVariables = "Octopus.Features.ConfigurationVariables";
+            public const string ConfigurationTransforms = "Octopus.Features.ConfigurationTransforms";
+            public const string SubstituteInFiles = "Octopus.Features.SubstituteInFiles";
+            public const string StructuredConfigurationVariables = "Octopus.Features.JsonConfigurationVariables";
+        }
     }
 }


### PR DESCRIPTION
## Background

Move `Feature` constants into Sashimi, so the corresponding projects can reference them correctly like `Octopus.Kubernetes`.

Please refer to this [Trello Card](https://trello.com/c/46u8HaeM/3736-cleanup-move-constants-to-sashimi) for more details.