### PR TITLE
Added a new resolver to the create target message handler

### DIFF
--- a/source/Server.Contracts/ServiceMessages/ICreateTargetServiceMessageHandler.cs
+++ b/source/Server.Contracts/ServiceMessages/ICreateTargetServiceMessageHandler.cs
@@ -15,6 +15,6 @@ namespace Sashimi.Server.Contracts.ServiceMessages
                                Func<string, string> certificateIdResolver, 
                                Func<string, string> workerPoolIdResolver, 
                                Func<string, AccountType> accountTypeResolver, 
-                               Func<string, FeedId> feedIdResolver);
+                               Func<string, string> feedIdResolver);
     }
 }

--- a/source/Server.Contracts/ServiceMessages/ICreateTargetServiceMessageHandler.cs
+++ b/source/Server.Contracts/ServiceMessages/ICreateTargetServiceMessageHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Octopus.Server.Extensibility.HostServices.Model.Feeds;
 using Octostache;
 using Sashimi.Server.Contracts.Accounts;
 using Sashimi.Server.Contracts.Endpoints;
@@ -8,6 +9,12 @@ namespace Sashimi.Server.Contracts.ServiceMessages
 {
     public interface ICreateTargetServiceMessageHandler : IServiceMessageHandler
     {
-        Endpoint BuildEndpoint(IDictionary<string, string> messageProperties, VariableDictionary variables, Func<string, string> accountIdResolver, Func<string, string> certificateIdResolver, Func<string, string> workerPoolIdResolver, Func<string, AccountType> accountTypeResolver);
+        Endpoint BuildEndpoint(IDictionary<string, string> messageProperties, 
+                               VariableDictionary variables, 
+                               Func<string, string> accountIdResolver, 
+                               Func<string, string> certificateIdResolver, 
+                               Func<string, string> workerPoolIdResolver, 
+                               Func<string, AccountType> accountTypeResolver, 
+                               Func<string, FeedId> feedIdResolver);
     }
 }


### PR DESCRIPTION
Kubernetes targets have the option of defining a worker image for health checks. These images require a feed to be resolved from a name or ID. This PR adds a new resolver to the message handler that creates targets to support resolving feeds from names.