### PR TITLE
Do not flat files on copy

### DIFF
--- a/source/Calamari.Scripting.Tests/Calamari.Scripting.Tests.csproj
+++ b/source/Calamari.Scripting.Tests/Calamari.Scripting.Tests.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="nunit" Version="3.13.1" />
+        <PackageReference Include="nunit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
         <PackageReference Include="NSubstitute" Version="4.2.2" />
         <PackageReference Include="Shouldly" Version="2.8.2" />

--- a/source/Calamari.Scripting/Calamari.Scripting.csproj
+++ b/source/Calamari.Scripting/Calamari.Scripting.csproj
@@ -15,7 +15,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Calamari.Common" Version="19.2.0" />
+        <PackageReference Include="Calamari.Common" Version="19.2.5" />
         <PackageReference Include="FSharp.Compiler.Tools" Version="4.0.0.1" />
         <PackageReference Include="scriptcs" Version="0.17.1" />
     </ItemGroup>

--- a/source/Calamari.Scripting/Calamari.Scripting.csproj
+++ b/source/Calamari.Scripting/Calamari.Scripting.csproj
@@ -32,7 +32,7 @@
             <Visible>false</Visible>
             <PackagePath>contentFiles/any/any/FSharp/</PackagePath>
             <PackageCopyToOutput>true</PackageCopyToOutput>
-            <PackageFlatten>true</PackageFlatten>
+            <PackageFlatten>false</PackageFlatten>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
         <Content Include="ScriptCS/*.*">
@@ -41,7 +41,7 @@
             <Pack>true</Pack>
             <PackagePath>contentFiles/any/any/ScriptCS/</PackagePath>
             <PackageCopyToOutput>true</PackageCopyToOutput>
-            <PackageFlatten>true</PackageFlatten>
+            <PackageFlatten>false</PackageFlatten>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
     </ItemGroup>

--- a/source/Calamari.Tests.Shared/Calamari.Tests.Shared.csproj
+++ b/source/Calamari.Tests.Shared/Calamari.Tests.Shared.csproj
@@ -14,9 +14,9 @@
 
     <ItemGroup>
         <PackageReference Include="Assent" Version="1.6.1" />
-        <PackageReference Include="Calamari.Common" Version="19.2.0" />
+        <PackageReference Include="Calamari.Common" Version="19.2.5" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="NUnit" Version="3.13.1" />
+        <PackageReference Include="NUnit" Version="3.13.2" />
         <PackageReference Include="Octopus.Diagnostics" Version="2.1.1" />
     </ItemGroup>
 

--- a/source/Sashimi.Aws.Accounts.Tests/Sashimi.Aws.Accounts.Tests.csproj
+++ b/source/Sashimi.Aws.Accounts.Tests/Sashimi.Aws.Accounts.Tests.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="4.2.1" />
-    <PackageReference Include="nunit" Version="3.13.1" />
+    <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 

--- a/source/Sashimi.Azure.Accounts.Tests/Sashimi.Azure.Accounts.Tests.csproj
+++ b/source/Sashimi.Azure.Accounts.Tests/Sashimi.Azure.Accounts.Tests.csproj
@@ -7,11 +7,11 @@
 
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="4.2.1" />
-    <PackageReference Include="nunit" Version="3.13.1" />
+    <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="13.0.0" />
+    <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.5" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Sashimi.Tests.Shared.Tests/Sashimi.Tests.Shared.Tests.csproj
+++ b/source/Sashimi.Tests.Shared.Tests/Sashimi.Tests.Shared.Tests.csproj
@@ -8,8 +8,8 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-        <PackageReference Include="NUnit" Version="3.13.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+        <PackageReference Include="NUnit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
     </ItemGroup>

--- a/source/Server.Contracts/Sashimi.Server.Contracts.csproj
+++ b/source/Server.Contracts/Sashimi.Server.Contracts.csproj
@@ -12,11 +12,11 @@
 
   <ItemGroup>
     <PackageReference Include="Octostache" Version="2.10.0" />
-    <PackageReference Include="Octopus.TinyTypes" Version="0.1.459" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="14.0.1" />
+    <PackageReference Include="Octopus.TinyTypes" Version="0.1.562" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="14.0.5" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.1" />
     <PackageReference Include="Octopus.Data" Version="6.0.0" />
-    <PackageReference Include="Octopus.CoreUtilities" Version="2.1.0" />
+    <PackageReference Include="Octopus.CoreUtilities" Version="2.1.184" />
     <PackageReference Include="FluentValidation" Version="8.6.2" />
   </ItemGroup>
 

--- a/source/Templates/NewStep/Sashimi.NamingIsHard/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Templates/NewStep/Sashimi.NamingIsHard/source/Calamari.Tests/Calamari.Tests.csproj
@@ -10,9 +10,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="nunit" Version="3.13.1" />
+        <PackageReference Include="nunit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
     </ItemGroup>
 

--- a/source/Templates/NewStep/Sashimi.NamingIsHard/source/Calamari/Calamari.csproj
+++ b/source/Templates/NewStep/Sashimi.NamingIsHard/source/Calamari/Calamari.csproj
@@ -10,7 +10,7 @@
         <IsPackable>true</IsPackable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Calamari.Common" Version="19.2.0" />
+        <PackageReference Include="Calamari.Common" Version="19.2.5" />
         <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/source/Templates/NewStep/Sashimi.NamingIsHard/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Templates/NewStep/Sashimi.NamingIsHard/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -9,10 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="nunit" Version="3.13.1" />
+        <PackageReference Include="nunit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-        <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="13.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+        <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.5" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
     </ItemGroup>
 

--- a/source/Templates/Sashimi.Template.Wrangler.Tests/Sashimi.Template.Wrangler.Tests.csproj
+++ b/source/Templates/Sashimi.Template.Wrangler.Tests/Sashimi.Template.Wrangler.Tests.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Calamari.Common" Version="19.2.0" />
+        <PackageReference Include="Calamari.Common" Version="19.2.5" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="nunit" Version="3.13.1" />
+        <PackageReference Include="nunit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
     </ItemGroup>
 


### PR DESCRIPTION
There was a bug in our csproj file when it comes to packaging content files (CSsript + FSharp), this bug sets a flag to true to flatten files on copy. This setting seems to NOT be honoured prior to v5.0.6!

The latest v5.0.6 of the dotnet SDK honors the flat setting, this causes the csfiles and fsfiles to be in the root path of the consuming project, which is wrong