### PR TITLE
Modify Cake build to work with dotnet cake tool and Nautilus agent

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "cake.tool": {
+      "version": "0.38.5",
+      "commands": [
+        "dotnet-cake"
+      ]
+    }
+  }
+}

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////
 // TOOLS
 //////////////////////////////////////////////////////////////////////
+#module nuget:?package=Cake.DotNetTool.Module&version=0.4.0
 #tool "dotnet:?package=GitVersion.Tool&version=5.3.6"
 #tool "nuget:?package=TeamCity.Dotnet.Integration&version=1.0.10"
 #addin "nuget:?package=SharpZipLib&version=1.2.0"

--- a/build.cake
+++ b/build.cake
@@ -220,7 +220,6 @@ Task("PackSashimi")
 
 Task("PublishPackageArtifacts")
     .IsDependentOn("PackSashimi")
-    .IsDependentOn("CreateTemplatesPackage")
     .Does(() =>
 {
     var packages = GetFiles($"{artifactsDir}*.{nugetVersion}.nupkg");

--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////
 // TOOLS
 //////////////////////////////////////////////////////////////////////
-#tool "nuget:?package=GitVersion.CommandLine&version=4.0.0"
+#tool "dotnet:?package=GitVersion.Tool&version=5.3.6"
 #tool "nuget:?package=TeamCity.Dotnet.Integration&version=1.0.10"
 #addin "nuget:?package=SharpZipLib&version=1.2.0"
 #addin "nuget:?package=Cake.Compression&version=0.2.4"

--- a/build.cake
+++ b/build.cake
@@ -4,6 +4,7 @@
 #module nuget:?package=Cake.DotNetTool.Module&version=0.4.0
 #tool "dotnet:?package=GitVersion.Tool&version=5.3.6"
 #tool "nuget:?package=TeamCity.Dotnet.Integration&version=1.0.10"
+#tool "nuget:?package=NuGet.CommandLine&version=5.9.1"
 #addin "nuget:?package=SharpZipLib&version=1.2.0"
 #addin "nuget:?package=Cake.Compression&version=0.2.4"
 
@@ -90,54 +91,6 @@ Task("Test")
 			});
         });
     });
-
-Task("CreateTemplatesPackage")
-   .IsDependentOn("Build")
-   .Does(() => {
-        var templateCakeFiles = GetFiles("./source/Templates/*.cake");
-
-        foreach(var cakeFile in templateCakeFiles)
-        {
-            var destination = Path.GetFullPath(Path.Combine(workingDir, cakeFile.GetFilenameWithoutExtension().FullPath));
-            EnsureDirectoryExists(destination);
-
-            CakeExecuteScript(cakeFile, new CakeSettings{
-                Arguments = new Dictionary<string, string>{
-                    {"destination", destination},
-                    {"nugetVersion", nugetVersion},
-                    {"source", Path.GetFullPath("./source")},
-                    {"artifactsDir", Path.GetFullPath(artifactsDir)},
-                    {"templatePath", Path.GetFullPath(Path.Combine("./source/Templates/", cakeFile.GetFilenameWithoutExtension().FullPath))}
-                }
-            });
-        }
-
-        var nuGetPackSettings   = new NuGetPackSettings {
-                                      Id                      = "Sashimi.Templates",
-                                      Version                 = nugetVersion,
-                                      Title                   = "Sashimi.Templates",
-                                      Authors                 = new[] {"Octopus Deploy"},
-                                      Owners                  = new[] {"Octopus Deploy"},
-                                      Description             = "Sashimi templates",
-                                      ProjectUrl              = new Uri(projectUrl),
-                                      License                 = new NuSpecLicense() { Type = "expression", Value = "Apache-2.0" },
-                                      RequireLicenseAcceptance= false,
-                                      Symbols                 = false,
-                                      NoPackageAnalysis       = true,
-                                      Files                   = new [] {
-                                                                           new NuSpecContent {Source = "**/*", Target = "content"},
-                                                                        },
-                                      BasePath                = workingDir,
-                                      OutputDirectory         = artifactsDir,
-                                      ArgumentCustomization   = args=>args.Append("-NoDefaultExcludes"),
-                                      PackageTypes            = new [] {
-                                                                            new NuSpecPackageType { Name = "Template" }
-                                                                       },
-                                      Repository              = new NuGetRepository { Branch = gitVersionInfo.BranchName, Commit = gitVersionInfo.Sha, Type = "git", Url = projectUrl + ".git" }
-                                  };
-
-        NuGetPack(nuGetPackSettings);
-   });
 
 Task("PublishCalamariProjects")
     .IsDependentOn("Build")


### PR DESCRIPTION
# Overview

This PR fixes the build for Sashimi, which is currently 🔴 and not coming back

## Details

At some point in recent history, the Sashimi build was changed to run on `nautilus` [as seen here (private)](https://build.octopushq.com/admin/editRequirements.html?id=buildType:OctopusDeploy_Libraries_Sashimi).

This change meant that the existing cake powershell bootstrapper was no longer being used to initiate the build, and instead the dotnet cake tool was used to bootstrap and run the cake build, like so:

```
set -ex
dotnet tool restore
dotnet tool run dotnet-cake -- --bootstrap --verbosity=%Cake.Verbosity%
dotnet tool run dotnet-cake -- --verbosity=%Cake.Verbosity%
```

While the build changes were made in TeamCity, it looks like the corresponding changes to the cake build scripts were not made.

This PR:

- Adds an appropriate `.config/dotnet-tools.json` file so that `dotnet tool restore` makes the cake tool available
- Ensures the `GitVersion` tool exists for the build to use - may have previously been available in the build environment instead
- Ensures the `Nuget` tool exists for the build to use - previously the powershell bootstrapper was responsible for acquiring this
- Removes the no-longer-used `CreateTemplatesPackage` build task