### PR TITLE
Lower case reference to ScriptCS to include it in the Calamari package

### DIFF
--- a/source/Calamari.Scripting/Calamari.Scripting.csproj
+++ b/source/Calamari.Scripting/Calamari.Scripting.csproj
@@ -35,11 +35,11 @@
             <PackageFlatten>true</PackageFlatten>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
-        <Content Include="ScriptCS/*.*">
-            <LinkBase>ScriptCS</LinkBase>
+        <Content Include="scriptcs/*.*">
+            <LinkBase>scriptcs</LinkBase>
             <Visible>false</Visible>
             <Pack>true</Pack>
-            <PackagePath>contentFiles/any/any/ScriptCS/</PackagePath>
+            <PackagePath>contentFiles/any/any/scriptcs/</PackagePath>
             <PackageCopyToOutput>true</PackageCopyToOutput>
             <PackageFlatten>true</PackageFlatten>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
# Bug

Due to the builds now being run on a case sensitive file system (in nautilus-linux) the glob to include ScriptCS files in the package was not matching the files and the files were missing.

# Fix

The glob is updated to match the case of the files on disk.