### PR TITLE
Bump to `Calamari.Common@19.4.6`

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "cake.tool": {
+      "version": "0.38.5",
+      "commands": [
+        "dotnet-cake"
+      ]
+    }
+  }
+}

--- a/source/Calamari.Scripting/Calamari.Scripting.csproj
+++ b/source/Calamari.Scripting/Calamari.Scripting.csproj
@@ -15,7 +15,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Calamari.Common" Version="19.2.5" />
+        <PackageReference Include="Calamari.Common" Version="19.4.6" />
         <PackageReference Include="FSharp.Compiler.Tools" Version="4.0.0.1" />
         <PackageReference Include="scriptcs" Version="0.17.1" />
     </ItemGroup>

--- a/source/Calamari.Scripting/Calamari.Scripting.csproj
+++ b/source/Calamari.Scripting/Calamari.Scripting.csproj
@@ -35,11 +35,11 @@
             <PackageFlatten>false</PackageFlatten>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
-        <Content Include="ScriptCS/*.*">
-            <LinkBase>ScriptCS</LinkBase>
+        <Content Include="scriptcs/*.*">
+            <LinkBase>scriptcs</LinkBase>
             <Visible>false</Visible>
             <Pack>true</Pack>
-            <PackagePath>contentFiles/any/any/ScriptCS/</PackagePath>
+            <PackagePath>contentFiles/any/any/scriptcs/</PackagePath>
             <PackageCopyToOutput>true</PackageCopyToOutput>
             <PackageFlatten>false</PackageFlatten>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/source/Templates/NewStep/Sashimi.NamingIsHard/source/Calamari/Calamari.csproj
+++ b/source/Templates/NewStep/Sashimi.NamingIsHard/source/Calamari/Calamari.csproj
@@ -10,7 +10,7 @@
         <IsPackable>true</IsPackable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Calamari.Common" Version="19.2.5" />
+        <PackageReference Include="Calamari.Common" Version="19.4.6" />
         <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/source/Templates/Sashimi.Template.Wrangler.Tests/Sashimi.Template.Wrangler.Tests.csproj
+++ b/source/Templates/Sashimi.Template.Wrangler.Tests/Sashimi.Template.Wrangler.Tests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Calamari.Common" Version="19.2.5" />
+        <PackageReference Include="Calamari.Common" Version="19.4.6" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="nunit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />


### PR DESCRIPTION
# Overview

This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.2.

Change: #754

Issue: OctopusDeploy/Issues#6941