### PR TITLE
Use TinyTypes for Deployment Action Container's FeedId

### DIFF
--- a/source/Server.Contracts/Endpoints/DeploymentActionContainer.cs
+++ b/source/Server.Contracts/Endpoints/DeploymentActionContainer.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
+using Octopus.Ocl.Converters;
+using Octopus.Server.MessageContracts.Features.Feeds;
 using Sashimi.Server.Contracts.Variables;
 
 namespace Sashimi.Server.Contracts.Endpoints
@@ -8,11 +11,14 @@ namespace Sashimi.Server.Contracts.Endpoints
     {
         public const string DefaultTag = "latest";
         public string? Image { get; set; }
-        public string? FeedId { get; set; }
+
+        [JsonProperty("FeedId")] // This is named FeedId for backward-compatibility as we don't yet want to change the underlying database JSON/schema.
+        [OclName("feed")]
+        public FeedIdOrName? FeedIdOrName { get; set; }
 
         public bool IsConfigured()
         {
-            return !string.IsNullOrEmpty(Image) && !string.IsNullOrEmpty(FeedId);
+            return !string.IsNullOrEmpty(Image) && FeedIdOrName is not null;
         }
 
         public IEnumerable<Variable> ContributeVariables()

--- a/source/Server.Contracts/Endpoints/DeploymentActionContainerResource.cs
+++ b/source/Server.Contracts/Endpoints/DeploymentActionContainerResource.cs
@@ -1,8 +1,10 @@
+using Octopus.Server.MessageContracts.Features.Feeds;
+
 namespace Sashimi.Server.Contracts.Endpoints
 {
     public class DeploymentActionContainerResource
     {
         public string? Image { get; set; }
-        public string? FeedId { get; set; }
+        public FeedIdOrName? FeedId { get; set; }
     }
 }

--- a/source/Server.Contracts/Sashimi.Server.Contracts.csproj
+++ b/source/Server.Contracts/Sashimi.Server.Contracts.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Octopus.Server.Extensibility" Version="14.0.5" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.1" />
     <PackageReference Include="Octopus.Data" Version="6.0.0" />
+    <PackageReference Include="Octopus.Ocl" Version="0.4.843" />
     <PackageReference Include="Octopus.CoreUtilities" Version="2.1.184" />
     <PackageReference Include="FluentValidation" Version="8.6.2" />
   </ItemGroup>


### PR DESCRIPTION
_These changes have already been reviewed and discussed over in #123, but targeted the wrong branch (and won't be going anywhere). Check out the notes on that PR if you're interested in any of the discussion._

Three small changes:
- Use `FeedIdOrName` TinyType for `DeploymentActionContainer.FeedId` and `DeploymentActionContainerResource.FeedId`.
- Change `DeploymentActionContainer.FeedId` type from `string` to `FeedIdOrName`
- Add `OclNameAttribute` with name as "feed" (makes it serialise a little nicer in the OCL)