### PR TITLE
Bump Calamari.Common from 20.3.6 to 20.3.9

### DIFF
--- a/source/Calamari.Scripting/Calamari.Scripting.csproj
+++ b/source/Calamari.Scripting/Calamari.Scripting.csproj
@@ -15,7 +15,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Calamari.Common" Version="20.3.6" />
+        <PackageReference Include="Calamari.Common" Version="20.3.9" />
         <PackageReference Include="FSharp.Compiler.Tools" Version="4.0.0.1" />
         <PackageReference Include="scriptcs" Version="0.17.1" />
     </ItemGroup>

--- a/source/Calamari.Tests.Shared/Calamari.Tests.Shared.csproj
+++ b/source/Calamari.Tests.Shared/Calamari.Tests.Shared.csproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="Assent" Version="1.6.1" />
-        <PackageReference Include="Calamari.Common" Version="20.3.6" />
+        <PackageReference Include="Calamari.Common" Version="20.3.9" />
         <PackageReference Include="FluentAssertions" Version="6.1.0" />
         <PackageReference Include="NUnit" Version="3.13.2" />
         <PackageReference Include="Octopus.Diagnostics" Version="2.1.2" />

--- a/source/Templates/NewStep/Sashimi.NamingIsHard/source/Calamari/Calamari.csproj
+++ b/source/Templates/NewStep/Sashimi.NamingIsHard/source/Calamari/Calamari.csproj
@@ -10,7 +10,7 @@
         <IsPackable>true</IsPackable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Calamari.Common" Version="20.3.6" />
+        <PackageReference Include="Calamari.Common" Version="20.3.9" />
         <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/source/Templates/Sashimi.Template.Wrangler.Tests/Sashimi.Template.Wrangler.Tests.csproj
+++ b/source/Templates/Sashimi.Template.Wrangler.Tests/Sashimi.Template.Wrangler.Tests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Calamari.Common" Version="20.3.6" />
+        <PackageReference Include="Calamari.Common" Version="20.3.9" />
         <PackageReference Include="FluentAssertions" Version="6.1.0" />
         <PackageReference Include="nunit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />


### PR DESCRIPTION
Merges in changes from https://github.com/OctopusDeploy/Calamari/pull/773

- Prevents unexpected masked characters printing to deployment log when no arguments are passed to Run a Script steps