### PR TITLE
Add isolation mutex name to Calamari command builder

### DIFF
--- a/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
+++ b/source/Sashimi.Tests.Shared/Server/TestCalamariCommandBuilder.cs
@@ -129,6 +129,11 @@ namespace Sashimi.Tests.Shared.Server
             throw new NotImplementedException();
         }
 
+        public ICalamariCommandBuilder WithIsolationName(string name)
+        {
+            throw new NotImplementedException();
+        }
+
         public string Describe()
         {
             throw new NotImplementedException();

--- a/source/Server.Contracts/CommandBuilders/ICalamariCommandBuilder.cs
+++ b/source/Server.Contracts/CommandBuilders/ICalamariCommandBuilder.cs
@@ -27,6 +27,7 @@ namespace Sashimi.Server.Contracts.CommandBuilders
         IActionHandlerResult Execute(ITaskLog taskLog);
         ICalamariCommandBuilder WithIsolation(ExecutionIsolation executionIsolation);
         ICalamariCommandBuilder WithIsolationTimeout(TimeSpan mutexTimeout);
+        ICalamariCommandBuilder WithIsolationName(string name);
         string Describe();
     }
 


### PR DESCRIPTION
This allows passing the mutex name from Octopus Server. Relates to https://github.com/OctopusDeploy/OctopusShared/pull/165