### PR TITLE
Bumps Calamari.Common to 18.1.7 (Server 2021.1 stream)

### DIFF
--- a/source/Calamari.Scripting/Calamari.Scripting.csproj
+++ b/source/Calamari.Scripting/Calamari.Scripting.csproj
@@ -15,7 +15,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Calamari.Common" Version="18.1.4" />
+        <PackageReference Include="Calamari.Common" Version="18.1.7" />
         <PackageReference Include="FSharp.Compiler.Tools" Version="4.0.0.1" />
         <PackageReference Include="scriptcs" Version="0.17.1" />
     </ItemGroup>

--- a/source/Calamari.Tests.Shared/Calamari.Tests.Shared.csproj
+++ b/source/Calamari.Tests.Shared/Calamari.Tests.Shared.csproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="Assent" Version="1.6.1" />
-        <PackageReference Include="Calamari.Common" Version="18.1.4" />
+        <PackageReference Include="Calamari.Common" Version="18.1.7" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="NUnit" Version="3.13.1" />
         <PackageReference Include="Octopus.Diagnostics" Version="1.3.5" />

--- a/source/Sashimi.Tests.Shared/Sashimi.Tests.Shared.csproj
+++ b/source/Sashimi.Tests.Shared/Sashimi.Tests.Shared.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Calamari.Tests.Shared\Calamari.Tests.Shared.csproj" />
     <ProjectReference Include="..\Server.Contracts\Sashimi.Server.Contracts.csproj" />
-    <PackageReference Include="Calamari.Common" Version="18.1.4" />
+    <PackageReference Include="Calamari.Common" Version="18.1.7" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Octostache" Version="2.9.4" />
   </ItemGroup>

--- a/source/Templates/NewStep/Sashimi.NamingIsHard/source/Calamari/Calamari.csproj
+++ b/source/Templates/NewStep/Sashimi.NamingIsHard/source/Calamari/Calamari.csproj
@@ -10,7 +10,7 @@
         <IsPackable>true</IsPackable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Calamari.Common" Version="18.1.4" />
+        <PackageReference Include="Calamari.Common" Version="18.1.7" />
         <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/source/Templates/Sashimi.Template.Wrangler.Tests/Sashimi.Template.Wrangler.Tests.csproj
+++ b/source/Templates/Sashimi.Template.Wrangler.Tests/Sashimi.Template.Wrangler.Tests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Calamari.Common" Version="18.1.4" />
+        <PackageReference Include="Calamari.Common" Version="18.1.7" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="nunit" Version="3.13.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.1.

Upstream change:
* OctopusDeploy/Calamari#805

To fix Issues:
* OctopusDeploy/Issues#6794
* OctopusDeploy/Issues#7177