### PR TITLE
Bumps Calamari.* to 20.4.2 (Server 2021.3 Stream)

### DIFF
--- a/source/Calamari.Scripting/Calamari.Scripting.csproj
+++ b/source/Calamari.Scripting/Calamari.Scripting.csproj
@@ -15,7 +15,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Calamari.Common" Version="20.3.9" />
+        <PackageReference Include="Calamari.Common" Version="20.4.2" />
         <PackageReference Include="FSharp.Compiler.Tools" Version="4.0.0.1" />
         <PackageReference Include="scriptcs" Version="0.17.1" />
     </ItemGroup>

--- a/source/Calamari.Tests.Shared/Calamari.Tests.Shared.csproj
+++ b/source/Calamari.Tests.Shared/Calamari.Tests.Shared.csproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="Assent" Version="1.6.1" />
-        <PackageReference Include="Calamari.Common" Version="20.3.9" />
+        <PackageReference Include="Calamari.Common" Version="20.4.2" />
         <PackageReference Include="FluentAssertions" Version="6.1.0" />
         <PackageReference Include="NUnit" Version="3.13.2" />
         <PackageReference Include="Octopus.Diagnostics" Version="2.1.2" />

--- a/source/Templates/NewStep/Sashimi.NamingIsHard/source/Calamari/Calamari.csproj
+++ b/source/Templates/NewStep/Sashimi.NamingIsHard/source/Calamari/Calamari.csproj
@@ -10,7 +10,7 @@
         <IsPackable>true</IsPackable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Calamari.Common" Version="20.3.9" />
+        <PackageReference Include="Calamari.Common" Version="20.4.2" />
         <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/source/Templates/Sashimi.Template.Wrangler.Tests/Sashimi.Template.Wrangler.Tests.csproj
+++ b/source/Templates/Sashimi.Template.Wrangler.Tests/Sashimi.Template.Wrangler.Tests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Calamari.Common" Version="20.3.9" />
+        <PackageReference Include="Calamari.Common" Version="20.4.2" />
         <PackageReference Include="FluentAssertions" Version="6.1.0" />
         <PackageReference Include="nunit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.3

Upstream change:
* OctopusDeploy/Calamari#815

* OctopusDeploy/Issues/issues/6794
* OctopusDeploy/Issues/issues/7177