### PR TITLE
Add executable helper from Sashimi.Tests.Shared to Calamari.Tests.Shared

### DIFF
--- a/source/Calamari.Tests.Shared/ExecutableHelper.cs
+++ b/source/Calamari.Tests.Shared/ExecutableHelper.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using System.Text;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing;
+
+namespace Calamari.Tests.Shared
+{
+    public static class ExecutableHelper
+    {
+        public static void AddExecutePermission(string exePath)
+        {
+            if (CalamariEnvironment.IsRunningOnWindows)
+                return;
+
+            var stdOut = new StringBuilder();
+            var stdError = new StringBuilder();
+            var result = SilentProcessRunner.ExecuteCommand("chmod",
+                                                            $"+x {exePath}",
+                                                            Path.GetDirectoryName(exePath) ?? string.Empty,
+                                                            s => stdOut.AppendLine(s),
+                                                            s => stdError.AppendLine(s));
+
+            if (result.ExitCode != 0)
+                throw new Exception(stdOut.ToString() + stdError);
+        }
+    }
+}


### PR DESCRIPTION
… for dependency management.

This is related from https://github.com/OctopusDeploy/Sashimi.GoogleCloud/pull/13 where integration tests have been ripped out of Sashimi half and put into Calamari, as we don't want Sashimi test dependencies in Calamari tests.